### PR TITLE
fix(space): "创建专属空间"的UI改进

### DIFF
--- a/src/renderer/i18n/locales/de.json
+++ b/src/renderer/i18n/locales/de.json
@@ -410,6 +410,7 @@
   "Source": "Quelle",
   "Source view": "Quellenansicht",
   "Space Name": "Space-Name",
+  "Name this space": "Gib diesem Space einen Namen",
   "Split view": "Geteilte Ansicht",
   "Start a new conversation to create history": "Starten Sie eine neue Konversation, um einen Verlauf zu erstellen",
   "Start Tunnel": "Tunnel starten",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -411,6 +411,7 @@
   "Source": "Source",
   "Source view": "Source view",
   "Space Name": "Space Name",
+  "Name this space": "Name this space",
   "Split view": "Split view",
   "Start a new conversation to create history": "Start a new conversation to create history",
   "Start Tunnel": "Start Tunnel",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -429,6 +429,7 @@
   "Source": "Fuente",
   "Source view": "Vista de fuente",
   "Space Name": "Nombre del espacio",
+  "Name this space": "Dale un nombre a este espacio",
   "Split view": "Vista dividida",
   "Start a new conversation to create history": "Inicia una nueva conversación para crear historial",
   "Start Tunnel": "Iniciar túnel",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -429,6 +429,7 @@
   "Source": "Source",
   "Source view": "Vue source",
   "Space Name": "Nom de l'espace",
+  "Name this space": "Donnez un nom à cet espace",
   "Split view": "Vue divisée",
   "Start a new conversation to create history": "Démarrez une nouvelle conversation pour créer un historique",
   "Start Tunnel": "Démarrer le tunnel",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -410,6 +410,7 @@
   "Source": "ソース",
   "Source view": "ソースビュー",
   "Space Name": "スペース名",
+  "Name this space": "このスペースに名前を付ける",
   "Split view": "分割ビュー",
   "Start a new conversation to create history": "新しい会話を開始して履歴を作成してください",
   "Start Tunnel": "トンネルを開始",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -412,6 +412,7 @@
   "Source": "来源",
   "Source view": "源码视图",
   "Space Name": "空间名称",
+  "Name this space": "为这个空间起一个名字",
   "Split view": "分屏视图",
   "Start a new conversation to create history": "开始新对话以创建历史记录",
   "Start Tunnel": "启动隧道",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -410,6 +410,7 @@
   "Source": "來源",
   "Source view": "來源檢視",
   "Space Name": "空間名稱",
+  "Name this space": "為這個空間起一個名字",
   "Split view": "分割檢視",
   "Start a new conversation to create history": "開始新對話以建立歷史記錄",
   "Start Tunnel": "啟動通道",


### PR DESCRIPTION
"创建专属空间" 的对话框，用户首次使用时，不容易注意到需要先填写空间名称，只会发现”创建“按钮一直处于禁用状态，就觉得被卡住了，很疑惑。我给周围同事试用时注意到了这个问题，因此做了以下改进：
 
    - 将空间名称的编辑框移动到下面来，视觉上更容易注意到
     - 自动让编辑框获得焦点，这样用户就知道这里是可以编辑的
     - 如果用户选了一个目录来保存空间，那么自动用目录的名字作为空间的名字候选，体验更好

## Testing
<!-- How did you test these changes? -->
- [✓] Tested locally with `npm run dev`
- [✓] Ran `npm run i18n`

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
<img width="433" height="528" alt="截屏2026-01-16 17 33 48" src="https://github.com/user-attachments/assets/9b9efe7f-3053-4698-8e8c-8dbf6a9ae4ea" />

