### PR TITLE
fix: resolve code block background color issue in light theme

### DIFF
--- a/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -56,9 +56,9 @@ function CodeBlock({
 
   // Code block
   return (
-    <div className="group relative my-3 rounded-xl overflow-hidden border border-border/50 bg-[#0d1117]">
+    <div className="group relative my-3 rounded-xl overflow-hidden border border-border/50 bg-card">
       {/* Header with language and copy button */}
-      <div className="flex items-center justify-between px-4 py-2 bg-[#161b22] border-b border-border/30">
+      <div className="flex items-center justify-between px-4 py-2 bg-secondary border-b border-border/30">
         <span className="text-xs text-muted-foreground/70 font-mono uppercase tracking-wide">
           {language || 'code'}
         </span>


### PR DESCRIPTION
## Summary

Fix code block background color display issue in light theme.

Fixes #30

## Problem

In light theme, the code block background color was hardcoded to dark (#0d1117), making text unreadable.

## Solution

Replace hardcoded dark background colors with theme-aware Tailwind variables:
- Code block background: `bg-[#0d1117]` → `bg-card`
- Code block header: `bg-[#161b22]` → `bg-secondary`

## Testing

- [x] Code blocks display correctly in light theme
- [x] Code blocks display correctly in dark theme
- [x] Text is clearly readable in both themes

## Modified Files

- `src/renderer/components/chat/MarkdownRenderer.tsx`