### PR TITLE
feat: make maxTurns configurable in Settings

### DIFF
--- a/src/main/services/agent/sdk-config.ts
+++ b/src/main/services/agent/sdk-config.ts
@@ -78,6 +78,8 @@ export interface BaseSdkOptionsParams {
   stderrHandler?: (data: string) => void
   /** Optional MCP servers configuration */
   mcpServers?: Record<string, any> | null
+  /** Maximum tool call turns per message (from config) */
+  maxTurns?: number
 }
 
 // ============================================
@@ -355,7 +357,7 @@ export function buildBaseSdkOptions(params: BaseSdkOptionsParams): Record<string
     }),
     // Use Halo's custom system prompt instead of SDK's 'claude_code' preset
     systemPrompt: buildSystemPrompt({ workDir, modelInfo: credentials.displayModel }),
-    maxTurns: 50,
+    maxTurns: params.maxTurns ?? 50,
     allowedTools: [...DEFAULT_ALLOWED_TOOLS],
     // Enable Skills loading from $CLAUDE_CONFIG_DIR/skills/ and <workspace>/.claude/skills/
     settingSources: ['user', 'project'],

--- a/src/main/services/agent/send-message.ts
+++ b/src/main/services/agent/send-message.ts
@@ -155,7 +155,8 @@ export async function sendMessage(
         console.error(`[Agent][${conversationId}] CLI stderr:`, data)
         stderrBuffer += data  // Accumulate for error reporting
       },
-      mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : null
+      mcpServers: Object.keys(mcpServers).length > 0 ? mcpServers : null,
+      maxTurns: config.agent?.maxTurns
     })
 
     // Apply dynamic configurations (AI Browser system prompt, Thinking mode)

--- a/src/main/services/agent/session-manager.ts
+++ b/src/main/services/agent/session-manager.ts
@@ -531,7 +531,8 @@ export async function ensureSessionWarm(
     stderrHandler: (data: string) => {
       console.error(`[Agent][${conversationId}] CLI stderr (warm):`, data)
     },
-    mcpServers: enabledMcpServers
+    mcpServers: enabledMcpServers,
+    maxTurns: config.agent?.maxTurns
   })
 
   try {

--- a/src/main/services/config.service.ts
+++ b/src/main/services/config.service.ts
@@ -321,6 +321,10 @@ interface HaloConfig {
   system: {
     autoLaunch: boolean
   }
+  // Agent behavior configuration
+  agent?: {
+    maxTurns: number
+  }
   remoteAccess: {
     enabled: boolean
     port: number
@@ -437,6 +441,9 @@ const DEFAULT_CONFIG: HaloConfig = {
   },
   system: {
     autoLaunch: false
+  },
+  agent: {
+    maxTurns: 50
   },
   remoteAccess: {
     enabled: false,
@@ -755,6 +762,7 @@ export function getConfig(): HaloConfig {
       permissions: { ...DEFAULT_CONFIG.permissions, ...parsed.permissions },
       appearance: { ...DEFAULT_CONFIG.appearance, ...parsed.appearance },
       system: { ...DEFAULT_CONFIG.system, ...parsed.system },
+      agent: { ...DEFAULT_CONFIG.agent, ...parsed.agent },
       onboarding: { ...DEFAULT_CONFIG.onboarding, ...parsed.onboarding },
       // mcpServers is a flat map, just use parsed value or default
       mcpServers: parsed.mcpServers || DEFAULT_CONFIG.mcpServers,
@@ -787,6 +795,9 @@ export function saveConfig(config: Partial<HaloConfig>): HaloConfig {
   }
   if (config.system) {
     newConfig.system = { ...currentConfig.system, ...config.system }
+  }
+  if (config.agent) {
+    newConfig.agent = { ...currentConfig.agent, ...config.agent }
   }
   if (config.onboarding) {
     newConfig.onboarding = { ...currentConfig.onboarding, ...config.onboarding }

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -108,6 +108,11 @@ export interface SystemConfig {
   autoLaunch: boolean;      // Launch on system startup
 }
 
+// Agent behavior configuration
+export interface AgentConfig {
+  maxTurns: number;         // Maximum tool call turns per message
+}
+
 // Remote access configuration
 export interface RemoteAccessConfig {
   enabled: boolean;
@@ -186,6 +191,7 @@ export interface HaloConfig {
   remoteAccess: RemoteAccessConfig;
   mcpServers: McpServersConfig;  // MCP servers configuration
   notifications?: NotificationConfig;  // Notification preferences
+  agent?: AgentConfig;  // Agent behavior settings
   layout?: LayoutConfig;  // Global layout preferences (panel sizes and visibility)
   isFirstLaunch: boolean;
 }
@@ -640,6 +646,7 @@ export const DEFAULT_CONFIG: HaloConfig = {
     port: 3456
   },
   mcpServers: {},  // Empty by default
+  agent: { maxTurns: 50 },  // Agent defaults
   isFirstLaunch: true
 };
 


### PR DESCRIPTION
Closes #44

## Summary

- Add configurable `maxTurns` setting under **Settings > System**, replacing the hardcoded value of `50`
- Introduce `AgentConfig` type with `agent.maxTurns` field across config service and renderer types
- Pass user-configured `maxTurns` through `BaseSdkOptionsParams` to the Claude Agent SDK session

## Problem

The `maxTurns` parameter controlling the maximum number of tool call rounds per message is hardcoded to `50` in `sdk-config.ts`. For complex, long-running tasks, the agent gets silently truncated mid-execution when it hits this limit, with no user-visible indication of why it stopped.

## Changes

| File | Change |
|---|---|
| `src/renderer/types/index.ts` | Add `AgentConfig` interface, update `HaloConfig` and `DEFAULT_CONFIG` |
| `src/main/services/config.service.ts` | Add `agent` config type, default value, `getConfig()` and `saveConfig()` merge logic |
| `src/main/services/agent/sdk-config.ts` | Accept `maxTurns` param in `BaseSdkOptionsParams`, use `params.maxTurns ?? 50` |
| `src/main/services/agent/send-message.ts` | Pass `config.agent?.maxTurns` to `buildBaseSdkOptions` |
| `src/main/services/agent/session-manager.ts` | Pass `config.agent?.maxTurns` to `buildBaseSdkOptions` |
| `src/renderer/components/settings/SystemSection.tsx` | Add number input UI with state, handler, and validation (range: 10–9999) |

## Design Decisions

- **Default**: `50` — preserves current behavior, no breaking change
- **Namespace**: `agent.maxTurns` under a new `agent` config group for clean separation
- **Injection**: Passed through `BaseSdkOptionsParams` to preserve the pure function design of `buildBaseSdkOptions`
- **Runtime**: Takes effect on the next message sent, no restart required
- **UI**: Number input following existing System section layout patterns (`border-t` separator, label + description + `?` tooltip)

## Test plan

- [ ] Verify default value shows as `50` in Settings > System
- [ ] Change value to `200`, send a message, verify agent runs beyond 50 tool calls if needed
- [ ] Set value below `10`, verify it clamps to `10` on blur
- [ ] Set value above `9999`, verify it clamps to `9999` on blur
- [ ] Restart app, verify the configured value persists