### PR TITLE
feat: improve artifact references and sidebar resizing interactions

### DIFF
--- a/src/main/http/routes/index.ts
+++ b/src/main/http/routes/index.ts
@@ -414,7 +414,10 @@ export function registerApiRoutes(app: Express): void {
   // ===== Artifact Routes =====
   app.get('/api/spaces/:spaceId/artifacts', async (req: Request, res: Response) => {
     try {
-      const artifacts = await listArtifacts(req.params.spaceId)
+      const rawMaxDepth = req.query.maxDepth
+      const parsedMaxDepth = typeof rawMaxDepth === 'string' ? Number.parseInt(rawMaxDepth, 10) : Number.NaN
+      const maxDepth = Number.isFinite(parsedMaxDepth) ? Math.max(0, parsedMaxDepth) : 2
+      const artifacts = await listArtifacts(req.params.spaceId, maxDepth)
       res.json({ success: true, data: artifacts })
     } catch (error) {
       res.json({ success: false, error: (error as Error).message })

--- a/src/main/ipc/artifact.ts
+++ b/src/main/ipc/artifact.ts
@@ -21,9 +21,9 @@ import {
 // Register all artifact handlers
 export function registerArtifactHandlers(): void {
   // List artifacts in a space (flat list for card view)
-  ipcMain.handle('artifact:list', async (_event, spaceId: string) => {
+  ipcMain.handle('artifact:list', async (_event, spaceId: string, maxDepth?: number) => {
     try {
-      const artifacts = await listArtifacts(spaceId)
+      const artifacts = await listArtifacts(spaceId, maxDepth)
       return { success: true, data: artifacts }
     } catch (error) {
       console.error('[IPC] artifact:list error:', error)

--- a/src/main/services/artifact.service.ts
+++ b/src/main/services/artifact.service.ts
@@ -31,6 +31,7 @@ export interface Artifact {
   name: string
   type: 'file' | 'folder'
   path: string
+  relativePath: string
   extension: string
   icon: string
   createdAt: string
@@ -57,7 +58,7 @@ function getWorkingDir(spaceId: string): string {
  * List all artifacts in a space
  * Uses caching and file watching for optimal performance
  */
-export async function listArtifacts(spaceId: string): Promise<Artifact[]> {
+export async function listArtifacts(spaceId: string, maxDepth: number = 2): Promise<Artifact[]> {
   console.log(`[Artifact] listArtifacts for space: ${spaceId}`)
 
   const workDir = getWorkingDir(spaceId)
@@ -67,7 +68,7 @@ export async function listArtifacts(spaceId: string): Promise<Artifact[]> {
     return []
   }
 
-  const cachedArtifacts = await listArtifactsCached(spaceId, workDir, 2)
+  const cachedArtifacts = await listArtifactsCached(spaceId, workDir, maxDepth)
 
   // Convert to Artifact format
   const artifacts: Artifact[] = cachedArtifacts.map(ca => ({
@@ -77,6 +78,7 @@ export async function listArtifacts(spaceId: string): Promise<Artifact[]> {
     name: ca.name,
     type: ca.type,
     path: ca.path,
+    relativePath: ca.relativePath,
     extension: ca.extension,
     icon: ca.icon,
     createdAt: ca.createdAt,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -145,7 +145,7 @@ export interface HaloAPI {
   onAgentSessionInfo: (callback: (data: unknown) => void) => () => void
 
   // Artifact
-  listArtifacts: (spaceId: string) => Promise<IpcResponse>
+  listArtifacts: (spaceId: string, maxDepth?: number) => Promise<IpcResponse>
   listArtifactsTree: (spaceId: string) => Promise<IpcResponse>
   loadArtifactChildren: (spaceId: string, dirPath: string) => Promise<IpcResponse>
   initArtifactWatcher: (spaceId: string) => Promise<IpcResponse>
@@ -496,7 +496,7 @@ const api: HaloAPI = {
   onAgentSessionInfo: (callback) => createEventListener('agent:session-info', callback),
 
   // Artifact
-  listArtifacts: (spaceId) => ipcRenderer.invoke('artifact:list', spaceId),
+  listArtifacts: (spaceId, maxDepth = 2) => ipcRenderer.invoke('artifact:list', spaceId, maxDepth),
   listArtifactsTree: (spaceId) => ipcRenderer.invoke('artifact:list-tree', spaceId),
   loadArtifactChildren: (spaceId, dirPath) => ipcRenderer.invoke('artifact:load-children', spaceId, dirPath),
   initArtifactWatcher: (spaceId) => ipcRenderer.invoke('artifact:init-watcher', spaceId),

--- a/src/renderer/api/index.ts
+++ b/src/renderer/api/index.ts
@@ -506,11 +506,11 @@ export const api = {
   },
 
   // ===== Artifact =====
-  listArtifacts: async (spaceId: string): Promise<ApiResponse> => {
+  listArtifacts: async (spaceId: string, maxDepth: number = 2): Promise<ApiResponse> => {
     if (isElectron()) {
-      return window.halo.listArtifacts(spaceId)
+      return window.halo.listArtifacts(spaceId, maxDepth)
     }
-    return httpRequest('GET', `/api/spaces/${spaceId}/artifacts`)
+    return httpRequest('GET', `/api/spaces/${spaceId}/artifacts?maxDepth=${maxDepth}`)
   },
 
   listArtifactsTree: async (spaceId: string): Promise<ApiResponse> => {

--- a/src/renderer/components/artifact/ArtifactCard.tsx
+++ b/src/renderer/components/artifact/ArtifactCard.tsx
@@ -18,6 +18,13 @@ const isWebMode = api.isRemoteMode()
 
 interface ArtifactCardProps {
   artifact: Artifact
+  onShowContextMenu?: (menu: {
+    x: number
+    y: number
+    path: string
+    relativePath: string
+    isFolder: boolean
+  }) => void
 }
 
 // Format file size
@@ -28,7 +35,7 @@ function formatSize(bytes?: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export function ArtifactCard({ artifact }: ArtifactCardProps) {
+export function ArtifactCard({ artifact, onShowContextMenu }: ArtifactCardProps) {
   const { t } = useTranslation()
   const [isHovered, setIsHovered] = useState(false)
   const openFile = useCanvasStore(state => state.openFile)
@@ -78,18 +85,26 @@ export function ArtifactCard({ artifact }: ArtifactCardProps) {
   }
 
   // Handle right-click to show in folder (desktop only)
-  const handleContextMenu = async (e: React.MouseEvent) => {
+  const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault()
-    if (isWebMode) return
-    try {
-      await api.showArtifactInFolder(artifact.path)
-    } catch (error) {
-      console.error('Failed to show in folder:', error)
-    }
+    e.stopPropagation()
+    onShowContextMenu?.({
+      x: e.clientX,
+      y: e.clientY,
+      path: artifact.path,
+      relativePath: artifact.relativePath,
+      isFolder
+    })
   }
 
   return (
     <div
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/halo-artifact-relative-path', artifact.relativePath)
+        e.dataTransfer.setData('text/plain', artifact.relativePath)
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onContextMenu={handleContextMenu}

--- a/src/renderer/components/artifact/ArtifactRail.tsx
+++ b/src/renderer/components/artifact/ArtifactRail.tsx
@@ -9,10 +9,19 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { ArtifactCard } from './ArtifactCard'
 import { ArtifactTree } from './ArtifactTree'
 import { api } from '../../api'
 import type { Artifact, ArtifactViewMode, ArtifactChangeEvent } from '../../types'
+
+export interface ArtifactContextMenuState {
+  x: number
+  y: number
+  path: string
+  relativePath: string
+  isFolder: boolean
+}
 import { useIsGenerating } from '../../stores/chat.store'
 import { useSpaceStore } from '../../stores/space.store'
 import { useOnboardingStore } from '../../stores/onboarding.store'
@@ -83,6 +92,7 @@ function normalizeArtifactFromEvent(item: unknown, fallbackSpaceId: string): Art
     extension: candidate.extension || '',
     icon: candidate.icon || 'file-text',
     createdAt: candidate.createdAt || new Date().toISOString(),
+    relativePath: candidate.relativePath || candidate.name,
     preview: undefined,
     size: typeof candidate.size === 'number' ? candidate.size : undefined
   }
@@ -107,6 +117,33 @@ export function ArtifactRail({
     }
   }, [spaceId])
 
+  const handleShowArtifactContextMenu = useCallback((menu: ArtifactContextMenuState) => {
+    setContextMenu(menu)
+  }, [])
+
+  const handleCloseArtifactContextMenu = useCallback(() => {
+    setContextMenu(null)
+  }, [])
+
+  const handleCopyRelativePath = useCallback(async (relativePath: string) => {
+    try {
+      await navigator.clipboard.writeText(relativePath)
+      setContextMenu(null)
+    } catch (error) {
+      console.error('[ArtifactRail] Failed to copy relative path:', error)
+    }
+  }, [])
+
+  const handleRevealInFolder = useCallback(async (path: string) => {
+    if (isWebMode) return
+    try {
+      await api.showArtifactInFolder(path)
+      setContextMenu(null)
+    } catch (error) {
+      console.error('[ArtifactRail] Failed to show in folder:', error)
+    }
+  }, [])
+
   const [artifacts, setArtifacts] = useState<Artifact[]>([])
   // Use external control if provided, otherwise internal state
   const isControlled = externalExpanded !== undefined
@@ -128,7 +165,9 @@ export function ArtifactRail({
   }, [initialWidth, isDragging])
   const [viewMode, setViewMode] = useState<ArtifactViewMode>(getInitialViewMode)
   const [mobileOverlayOpen, setMobileOverlayOpen] = useState(false)
+  const [contextMenu, setContextMenu] = useState<ArtifactContextMenuState | null>(null)
   const railRef = useRef<HTMLDivElement>(null)
+  const contextMenuRef = useRef<HTMLDivElement>(null)
   const onWidthChangeRef = useRef(onWidthChange)
   onWidthChangeRef.current = onWidthChange
   const isGenerating = useIsGenerating()
@@ -230,13 +269,37 @@ export function ArtifactRail({
     }
   }, [isMobile, mobileOverlayOpen])
 
+  useEffect(() => {
+    if (!contextMenu) return
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (contextMenuRef.current && !contextMenuRef.current.contains(event.target as Node)) {
+        setContextMenu(null)
+      }
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setContextMenu(null)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleEscape)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [contextMenu])
+
   // Load artifacts from the main process
   const loadArtifacts = useCallback(async () => {
     if (!spaceId) return
 
     try {
       setIsLoading(true)
-      const response = await api.listArtifacts(spaceId)
+      const response = await api.listArtifacts(spaceId, 5)
       if (response.success && response.data) {
         setArtifacts(response.data as Artifact[])
       }
@@ -336,7 +399,10 @@ export function ArtifactRail({
   const renderContent = () => (
     <div className="flex-1 overflow-hidden">
       {viewMode === 'tree' ? (
-        <ArtifactTree spaceId={spaceId} />
+        <ArtifactTree
+          spaceId={spaceId}
+          onShowContextMenu={handleShowArtifactContextMenu}
+        />
       ) : (
         <div className="h-full overflow-auto p-2">
           {isLoading ? (
@@ -370,7 +436,10 @@ export function ArtifactRail({
                     data-onboarding={isOnboardingArtifact && isOnboardingViewStep ? 'artifact-card' : undefined}
                     onClick={isOnboardingArtifact && isOnboardingViewStep ? handleOnboardingArtifactClick : undefined}
                   >
-                    <ArtifactCard artifact={artifact} />
+                    <ArtifactCard
+                      artifact={artifact}
+                      onShowContextMenu={handleShowArtifactContextMenu}
+                    />
                   </div>
                 )
               })}
@@ -598,6 +667,36 @@ export function ArtifactRail({
             </>
           )}
         </div>
+      )}
+
+      {contextMenu && createPortal(
+        <div
+          ref={contextMenuRef}
+          className="fixed z-[9999] min-w-[180px] bg-popover border border-border rounded-lg shadow-lg py-1"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          <button
+            onClick={() => handleCopyRelativePath(contextMenu.relativePath)}
+            className="w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-secondary transition-colors text-left"
+          >
+            <span>{t('Copy relative path')}</span>
+          </button>
+          {!isWebMode && (
+            <button
+              onClick={() => handleRevealInFolder(contextMenu.path)}
+              className="w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-secondary transition-colors text-left"
+            >
+              <span>{contextMenu.isFolder ? t('Open folder location') : t('Show in folder')}</span>
+            </button>
+          )}
+          <button
+            onClick={handleCloseArtifactContextMenu}
+            className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground hover:bg-secondary transition-colors text-left"
+          >
+            <span>{t('Close')}</span>
+          </button>
+        </div>,
+        document.body
       )}
     </div>
   )

--- a/src/renderer/components/artifact/ArtifactTree.tsx
+++ b/src/renderer/components/artifact/ArtifactTree.tsx
@@ -51,6 +51,13 @@ function isDimmed(name: string): boolean {
 
 interface ArtifactTreeProps {
   spaceId: string
+  onShowContextMenu?: (menu: {
+    x: number
+    y: number
+    path: string
+    relativePath: string
+    isFolder: boolean
+  }) => void
 }
 
 // Fixed offsets for tree height calculation (in pixels)
@@ -80,6 +87,13 @@ interface LazyLoadContextType {
   loadingPaths: Set<string>
 }
 const LazyLoadContext = createContext<LazyLoadContextType | null>(null)
+const ArtifactContextMenuContext = createContext<((menu: {
+  x: number
+  y: number
+  path: string
+  relativePath: string
+  isFolder: boolean
+}) => void) | null>(null)
 
 // ============================================
 // Index helpers — maintain Map<path, node> for O(1) lookup
@@ -142,7 +156,7 @@ function mergeChildren(
 // ArtifactTree component
 // ============================================
 
-export function ArtifactTree({ spaceId }: ArtifactTreeProps) {
+export function ArtifactTree({ spaceId, onShowContextMenu }: ArtifactTreeProps) {
   const { t } = useTranslation()
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set())
   const treeHeight = useTreeHeight()
@@ -299,34 +313,36 @@ export function ArtifactTree({ spaceId }: ArtifactTreeProps) {
 
   return (
     <OpenFileContext.Provider value={openFile}>
-      <LazyLoadContext.Provider value={lazyLoadValue}>
-        <div className="flex flex-col h-full">
-          {/* Header */}
-          <div className="flex-shrink-0 bg-card px-2 py-1.5 border-b border-border/50 text-[10px] text-muted-foreground/80 [.light_&]:text-muted-foreground uppercase tracking-wider">
-            {t('Files')}
-          </div>
+      <ArtifactContextMenuContext.Provider value={onShowContextMenu ?? null}>
+        <LazyLoadContext.Provider value={lazyLoadValue}>
+          <div className="flex flex-col h-full">
+            {/* Header */}
+            <div className="flex-shrink-0 bg-card px-2 py-1.5 border-b border-border/50 text-[10px] text-muted-foreground/80 [.light_&]:text-muted-foreground uppercase tracking-wider">
+              {t('Files')}
+            </div>
 
-          {/* Tree — uses window height based calculation */}
-          <div className="flex-1 overflow-hidden">
-            <Tree<ArtifactTreeNode>
-              data={treeData}
-              openByDefault={false}
-              width="100%"
-              height={treeHeight}
-              indent={16}
-              rowHeight={26}
-              overscanCount={5}
-              paddingTop={4}
-              paddingBottom={4}
-              disableDrag
-              disableDrop
-              disableEdit
-            >
-              {TreeNodeComponent}
-            </Tree>
+            {/* Tree — uses window height based calculation */}
+            <div className="flex-1 overflow-hidden">
+              <Tree<ArtifactTreeNode>
+                data={treeData}
+                openByDefault={false}
+                width="100%"
+                height={treeHeight}
+                indent={16}
+                rowHeight={26}
+                overscanCount={5}
+                paddingTop={4}
+                paddingBottom={4}
+                disableDrag
+                disableDrop
+                disableEdit
+              >
+                {TreeNodeComponent}
+              </Tree>
+            </div>
           </div>
-        </div>
-      </LazyLoadContext.Provider>
+        </LazyLoadContext.Provider>
+      </ArtifactContextMenuContext.Provider>
     </OpenFileContext.Provider>
   )
 }
@@ -336,6 +352,7 @@ export function ArtifactTree({ spaceId }: ArtifactTreeProps) {
 // ============================================
 
 function TreeNodeComponent({ node, style, dragHandle }: NodeRendererProps<ArtifactTreeNode>) {
+  const contextMenuHandler = useContext(ArtifactContextMenuContext)
   const { t } = useTranslation()
   const openFile = useContext(OpenFileContext)
   const lazyLoad = useContext(LazyLoadContext)
@@ -401,22 +418,28 @@ function TreeNodeComponent({ node, style, dragHandle }: NodeRendererProps<Artifa
   }
 
   // Handle right-click — show in folder (desktop only)
-  const handleContextMenu = async (e: React.MouseEvent) => {
+  const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (!isWebMode) {
-      try {
-        await api.showArtifactInFolder(data.path)
-      } catch (error) {
-        console.error('Failed to show in folder:', error)
-      }
-    }
+    contextMenuHandler?.({
+      x: e.clientX,
+      y: e.clientY,
+      path: data.path,
+      relativePath: data.relativePath,
+      isFolder
+    })
   }
 
   return (
     <div
       ref={dragHandle}
       style={style}
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/halo-artifact-relative-path', data.relativePath)
+        e.dataTransfer.setData('text/plain', data.relativePath)
+        e.dataTransfer.effectAllowed = 'copy'
+      }}
       onClick={handleClick}
       onDoubleClick={handleDoubleClickFile}
       onContextMenu={handleContextMenu}

--- a/src/renderer/components/chat/ChatView.tsx
+++ b/src/renderer/components/chat/ChatView.tsx
@@ -26,7 +26,7 @@ import {
   getOnboardingPrompt,
 } from '../onboarding/onboardingData'
 import { api } from '../../api'
-import type { ImageAttachment } from '../../types'
+import type { ImageAttachment, Artifact } from '../../types'
 import type { SlashCommandItem } from '../../types/slash-command'
 import { useTranslation } from '../../i18n'
 
@@ -63,6 +63,7 @@ export function ChatView({ isCompact = false }: ChatViewProps) {
   const [mockUserMessage, setMockUserMessage] = useState<string | null>(null)
   const [mockAiResponse, setMockAiResponse] = useState<string | null>(null)
   const [mockStreamingContent, setMockStreamingContent] = useState<string>('')
+  const [mentionArtifacts, setMentionArtifacts] = useState<Artifact[]>([])
 
   // Clear mock state when onboarding completes
   useEffect(() => {
@@ -221,6 +222,34 @@ export function ChatView({ isCompact = false }: ChatViewProps) {
   const onboardingPrompt = getOnboardingPrompt(t)
   const onboardingResponse = getOnboardingAiResponse(t)
   const onboardingHtml = getOnboardingHtmlArtifact(t)
+
+  useEffect(() => {
+    if (!currentSpace?.id) {
+      setMentionArtifacts([])
+      return
+    }
+
+    let cancelled = false
+
+    const loadMentionArtifacts = async () => {
+      try {
+        const response = await api.listArtifacts(currentSpace.id, 5)
+        if (!cancelled && response.success && response.data) {
+          setMentionArtifacts(response.data as Artifact[])
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('[ChatView] Failed to load mention artifacts:', error)
+        }
+      }
+    }
+
+    loadMentionArtifacts()
+
+    return () => {
+      cancelled = true
+    }
+  }, [currentSpace?.id])
 
   // Handle mock onboarding send
   const handleOnboardingSend = useCallback(async () => {
@@ -384,6 +413,7 @@ export function ChatView({ isCompact = false }: ChatViewProps) {
         placeholder={isCompact ? t('Continue conversation...') : (currentSpace?.isTemp ? t('Say something to Halo...') : t('Continue conversation...'))}
         isCompact={isCompact}
         slashCommands={slashCommands}
+        mentionArtifacts={mentionArtifacts}
       />
     </div>
   )

--- a/src/renderer/components/chat/ConversationList.tsx
+++ b/src/renderer/components/chat/ConversationList.tsx
@@ -23,7 +23,13 @@ import type { ConversationMeta } from '../../types'
 const MIN_WIDTH = 140
 const MAX_WIDTH = 360
 const DEFAULT_WIDTH = 260
+const MIN_TOP_SECTION_HEIGHT = 80
+const DEFAULT_TOP_SECTION_HEIGHT = 180
 const clampWidth = (v: number) => Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, v))
+const clampTopSectionHeight = (value: number, containerHeight: number) => {
+  const maxAllowed = Math.max(MIN_TOP_SECTION_HEIGHT, containerHeight - 160)
+  return Math.min(maxAllowed, Math.max(MIN_TOP_SECTION_HEIGHT, value))
+}
 
 interface ConversationListProps {
   onClose?: () => void
@@ -53,9 +59,13 @@ export const ConversationList = memo(function ConversationList({
 
   // Width state - initialized from persisted config
   const initialWidth = layoutConfig?.sidebarWidth
+  const initialTopSectionHeight = layoutConfig?.sidebarTopSectionHeight
   const [width, setWidth] = useState(initialWidth != null ? clampWidth(initialWidth) : DEFAULT_WIDTH)
   const [isDragging, setIsDragging] = useState(false)
+  const [isDraggingTopSection, setIsDraggingTopSection] = useState(false)
   const widthRef = useRef(width)
+  const topSectionHeightRef = useRef(initialTopSectionHeight ?? DEFAULT_TOP_SECTION_HEIGHT)
+  const [topSectionHeight, setTopSectionHeight] = useState(topSectionHeightRef.current)
 
   // Sync width when config arrives asynchronously
   useEffect(() => {
@@ -65,6 +75,13 @@ export const ConversationList = memo(function ConversationList({
       widthRef.current = clamped
     }
   }, [initialWidth, isDragging])
+
+  useEffect(() => {
+    if (initialTopSectionHeight !== undefined && !isDraggingTopSection) {
+      topSectionHeightRef.current = initialTopSectionHeight
+      setTopSectionHeight(initialTopSectionHeight)
+    }
+  }, [initialTopSectionHeight, isDraggingTopSection])
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editingTitle, setEditingTitle] = useState('')
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null)
@@ -77,6 +94,11 @@ export const ConversationList = memo(function ConversationList({
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     setIsDragging(true)
+  }, [])
+
+  const handleTopSectionMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsDraggingTopSection(true)
   }, [])
 
   useEffect(() => {
@@ -111,6 +133,38 @@ export const ConversationList = memo(function ConversationList({
       document.removeEventListener('mouseup', handleMouseUp)
     }
   }, [isDragging])
+
+  useEffect(() => {
+    if (!isDraggingTopSection) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!containerRef.current) return
+      const rect = containerRef.current.getBoundingClientRect()
+      const offsetY = e.clientY - rect.top - 48
+      const clamped = clampTopSectionHeight(offsetY, rect.height)
+      setTopSectionHeight(clamped)
+      topSectionHeightRef.current = clamped
+    }
+
+    const handleMouseUp = () => {
+      setIsDraggingTopSection(false)
+      const currentConfig = useAppStore.getState().config
+      if (currentConfig) {
+        useAppStore.getState().updateConfig({ layout: { ...currentConfig.layout, sidebarTopSectionHeight: topSectionHeightRef.current } })
+      }
+      api.setConfig({ layout: { sidebarTopSectionHeight: topSectionHeightRef.current } }).catch(err =>
+        console.error('[ConversationList] Failed to persist sidebar top section height:', err)
+      )
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isDraggingTopSection])
 
   // Close dropdown menu on outside click
   useEffect(() => {
@@ -296,14 +350,25 @@ export const ConversationList = memo(function ConversationList({
         )}
       </div>
 
-      {/* Automation apps status badge — quick jump to AppsPage */}
-      <AutomationBadge />
+      {/* Top resizable section */}
+      <div style={{ height: topSectionHeight }} className="flex flex-col overflow-hidden">
+        {/* Automation apps status badge — quick jump to AppsPage */}
+        <AutomationBadge />
 
-      {/* Pinned section - pinned conversations at top of sidebar (skip when hidden to avoid pulse selector cost) */}
-      {visible && <PulseSidebarSection />}
+        {/* Pinned section - pinned conversations at top of sidebar (skip when hidden to avoid pulse selector cost) */}
+        <div className="flex-1 overflow-auto">
+          {visible && <PulseSidebarSection />}
+        </div>
+      </div>
+
+      <div
+        className={`h-1.5 cursor-row-resize hover:bg-primary/50 transition-colors ${isDraggingTopSection ? 'bg-primary/50' : ''}`}
+        onMouseDown={handleTopSectionMouseDown}
+        title={t('Drag to resize sections')}
+      />
 
       {/* Conversation list - virtualized for performance with large lists */}
-      <div className="flex-1 overflow-hidden">
+      <div className="flex-1 overflow-hidden min-h-0">
         <Virtuoso
           data={conversations}
           overscan={200}

--- a/src/renderer/components/chat/InputArea.tsx
+++ b/src/renderer/components/chat/InputArea.tsx
@@ -26,7 +26,7 @@ import { useAIBrowserStore } from '../../stores/ai-browser.store'
 import { getOnboardingPrompt } from '../onboarding/onboardingData'
 import { ImageAttachmentPreview } from './ImageAttachmentPreview'
 import { processImage, isValidImageType, formatFileSize } from '../../utils/imageProcessor'
-import type { ImageAttachment } from '../../types'
+import type { ImageAttachment, Artifact } from '../../types'
 import { useTranslation } from '../../i18n'
 import { SlashCommandMenu, filterSlashCommands } from './SlashCommandMenu'
 import type { SlashCommandItem } from '../../types/slash-command'
@@ -39,6 +39,7 @@ interface InputAreaProps {
   isCompact?: boolean
   /** Available slash commands for the "/" quick-input autocomplete */
   slashCommands?: SlashCommandItem[]
+  mentionArtifacts?: Artifact[]
 }
 
 // Image constraints
@@ -51,7 +52,60 @@ interface ImageError {
   message: string
 }
 
-export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact = false, slashCommands = [] }: InputAreaProps) {
+interface MentionMatch {
+  query: string
+  start: number
+  end: number
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function getMentionMatch(value: string, cursorPosition: number): MentionMatch | null {
+  const beforeCursor = value.slice(0, cursorPosition)
+  const match = beforeCursor.match(/(^|\s)@([^\s@]*)$/)
+  if (!match || match.index === undefined) return null
+
+  const start = match.index + match[1].length
+  return {
+    query: match[2] || '',
+    start,
+    end: cursorPosition
+  }
+}
+
+function normalizePathLike(value: string): string {
+  return value.replace(/\\/g, '/').trim().toLowerCase()
+}
+
+function matchesFuzzyPathPrefix(relativePath: string, query: string): boolean {
+  const normalizedPath = normalizePathLike(relativePath)
+  const normalizedQuery = normalizePathLike(query)
+
+  if (!normalizedQuery) return true
+  if (normalizedPath.includes(normalizedQuery)) return true
+
+  const pathSegments = normalizedPath.split('/').filter(Boolean)
+  const querySegments = normalizedQuery.split('/').filter(Boolean)
+
+  if (querySegments.length === 0) return true
+  if (querySegments.length > pathSegments.length) return false
+
+  for (let i = 0; i < querySegments.length; i += 1) {
+    if (!pathSegments[i]?.startsWith(querySegments[i])) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function formatArtifactReference(relativePath: string): string {
+  return `\`${relativePath}\``
+}
+
+export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact = false, slashCommands = [], mentionArtifacts = [] }: InputAreaProps) {
   const { t } = useTranslation()
   const [content, setContent] = useState('')
   const [isFocused, setIsFocused] = useState(false)
@@ -64,6 +118,8 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
   // Slash-command autocomplete
   const [slashMenuOpen, setSlashMenuOpen] = useState(false)
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0)
+  const [mentionMenuOpen, setMentionMenuOpen] = useState(false)
+  const [mentionSelectedIndex, setMentionSelectedIndex] = useState(0)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const attachMenuRef = useRef<HTMLDivElement>(null)
@@ -203,6 +259,11 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
     e.preventDefault()
     setIsDragOver(false)
 
+    const referencePath = e.dataTransfer.getData('text/halo-artifact-relative-path') || e.dataTransfer.getData('text/plain')
+    if (referencePath && handleDropReference(referencePath)) {
+      return
+    }
+
     const files = Array.from(e.dataTransfer.files).filter(file => isValidImageType(file))
 
     if (files.length > 0) {
@@ -255,6 +316,10 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
 
   // `slashFilter` is the text typed after "/" — drives filtering and menu visibility.
   const slashFilter = slashMenuOpen && content.startsWith('/') ? content.slice(1) : ''
+  const mentionMatch = useMemo(() => {
+    const cursor = textareaRef.current?.selectionStart ?? content.length
+    return getMentionMatch(content, cursor)
+  }, [content])
 
   // Pre-filtered, pre-sorted list — single source of truth for rendering and keyboard nav.
   // Only computed when the menu is open; returns [] otherwise (zero cost when closed).
@@ -263,9 +328,70 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
     [slashCommands, slashFilter, slashMenuOpen]
   )
 
+  const filteredMentionArtifacts = useMemo(() => {
+    if (!mentionMenuOpen) return []
+
+    const query = mentionMatch?.query.trim() || ''
+    const normalizedQuery = normalizePathLike(query)
+    const artifacts = [...mentionArtifacts]
+
+    const score = (artifact: Artifact) => {
+      const name = normalizePathLike(artifact.name)
+      const relativePath = normalizePathLike(artifact.relativePath)
+      const pathSegments = relativePath.split('/').filter(Boolean)
+      const querySegments = normalizedQuery.split('/').filter(Boolean)
+
+      if (!normalizedQuery) return artifact.type === 'folder' ? 0 : 1
+      if (relativePath === normalizedQuery || name === normalizedQuery) return 0
+      if (pathSegments[0]?.startsWith(querySegments[0] || '')) return 1
+      if (pathSegments.every((segment, index) => !querySegments[index] || segment.startsWith(querySegments[index]))) return 2
+      if (relativePath.startsWith(normalizedQuery)) return 3
+      if (name.startsWith(normalizedQuery)) return 4
+      if (relativePath.includes(normalizedQuery)) return 5
+      return 10
+    }
+
+    return artifacts
+      .filter((artifact) => matchesFuzzyPathPrefix(artifact.relativePath, query))
+      .sort((a, b) => {
+        const diff = score(a) - score(b)
+        if (diff !== 0) return diff
+        if (a.type !== b.type) return a.type === 'folder' ? -1 : 1
+        return a.relativePath.localeCompare(b.relativePath)
+      })
+      .slice(0, 50)
+  }, [mentionArtifacts, mentionMatch, mentionMenuOpen])
+
   const handleSlashClose = () => {
     setSlashMenuOpen(false)
     setSlashSelectedIndex(0)
+  }
+
+  const handleMentionClose = () => {
+    setMentionMenuOpen(false)
+    setMentionSelectedIndex(0)
+  }
+
+  const insertMention = (relativePath: string) => {
+    const currentCursor = textareaRef.current?.selectionStart ?? content.length
+    const match = getMentionMatch(content, currentCursor)
+    if (!match) return
+
+    const mentionText = formatArtifactReference(relativePath)
+    const suffix = content.slice(match.end)
+    const needsTrailingSpace = suffix.length === 0 || !/^\s/.test(suffix)
+    const nextContent = `${content.slice(0, match.start)}${mentionText}${needsTrailingSpace ? ' ' : ''}${suffix}`
+    const nextCursor = content.slice(0, match.start).length + mentionText.length + (needsTrailingSpace ? 1 : 0)
+
+    setContent(nextContent)
+    handleMentionClose()
+
+    requestAnimationFrame(() => {
+      if (textareaRef.current) {
+        textareaRef.current.focus()
+        textareaRef.current.setSelectionRange(nextCursor, nextCursor)
+      }
+    })
   }
 
   const handleSlashSelect = (item: SlashCommandItem) => {
@@ -284,6 +410,29 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
         textareaRef.current.setSelectionRange(len, len)
       }
     })
+  }
+
+  const handleDropReference = (rawPath: string) => {
+    const normalizedPath = normalizePathLike(rawPath)
+    const escapedPath = escapeRegExp(normalizedPath)
+    const exactMatch = mentionArtifacts.find(artifact => normalizePathLike(artifact.relativePath) === normalizedPath)
+    const partialMatch = mentionArtifacts.find(artifact => new RegExp(`(^|/)${escapedPath}$`, 'i').test(normalizePathLike(artifact.relativePath)))
+    const target = exactMatch || partialMatch
+    if (!target) return false
+
+    const prefix = content && !content.endsWith(' ') && !content.endsWith('\n') ? ' ' : ''
+    const nextContent = `${content}${prefix}${formatArtifactReference(target.relativePath)} `
+    setContent(nextContent)
+    handleMentionClose()
+
+    requestAnimationFrame(() => {
+      if (textareaRef.current) {
+        textareaRef.current.focus()
+        const len = nextContent.length
+        textareaRef.current.setSelectionRange(len, len)
+      }
+    })
+    return true
   }
 
   // Handle send
@@ -319,6 +468,34 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
 
     // ── Slash-command menu navigation ─────────────────────────────────────────
     // filteredSlashCommands is already computed by useMemo — no extra filtering here.
+    if (mentionMenuOpen && filteredMentionArtifacts.length > 0) {
+      const filteredLen = filteredMentionArtifacts.length
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setMentionSelectedIndex((i) => (i + 1) % filteredLen)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setMentionSelectedIndex((i) => (i - 1 + filteredLen) % filteredLen)
+        return
+      }
+      if ((e.key === 'Enter' && !e.shiftKey) || e.key === 'Tab') {
+        e.preventDefault()
+        const selected = filteredMentionArtifacts[mentionSelectedIndex]
+        if (selected) {
+          insertMention(selected.relativePath)
+        }
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        handleMentionClose()
+        return
+      }
+    }
+
     if (slashMenuOpen && filteredSlashCommands.length > 0) {
       const filteredLen = filteredSlashCommands.length
 
@@ -423,6 +600,35 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
               onClose={handleSlashClose}
             />
           )}
+          {mentionMenuOpen && filteredMentionArtifacts.length > 0 && (
+            <div className="absolute bottom-full left-0 mb-2 w-full max-w-md bg-popover border border-border rounded-xl shadow-lg z-30 overflow-hidden">
+              <div className="max-h-[336px] overflow-y-auto py-1">
+                {filteredMentionArtifacts.map((artifact, index) => {
+                  const isSelected = index === mentionSelectedIndex
+                  return (
+                    <button
+                      key={`${artifact.path}-${artifact.type}`}
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        insertMention(artifact.relativePath)
+                      }}
+                      className={`w-full flex items-center gap-2 text-left min-h-[38px] border-l-2 ${isSelected ? 'bg-primary/10 border-primary pl-2.5 pr-3' : 'border-transparent pl-2.5 pr-3 hover:bg-muted/50'}`}
+                    >
+                      <span className="text-xs font-medium text-primary/80 shrink-0">
+                        {artifact.type === 'folder' ? t('Folder') : t('File')}
+                      </span>
+                      <span className="text-sm truncate flex-1 min-w-0">{artifact.relativePath}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              <div className="border-t border-border/40 px-3 py-1.5 flex items-center gap-3 text-[10px] text-muted-foreground/40 select-none">
+                <span>↑↓ {t('navigate')}</span>
+                <span>↵ {t('select')}</span>
+                <span>Esc {t('close')}</span>
+              </div>
+            </div>
+          )}
           {/* Image preview area */}
           {hasImages && (
             <ImageAttachmentPreview
@@ -475,8 +681,18 @@ export function InputArea({ onSend, onStop, isGenerating, placeholder, isCompact
                 if (looksLikeCommand) {
                   setSlashMenuOpen(true)
                   setSlashSelectedIndex(0)
+                  setMentionMenuOpen(false)
                 } else {
                   setSlashMenuOpen(false)
+                }
+
+                const nextCursor = e.target.selectionStart ?? val.length
+                const nextMentionMatch = getMentionMatch(val, nextCursor)
+                if (nextMentionMatch && mentionArtifacts.length > 0) {
+                  setMentionMenuOpen(true)
+                  setMentionSelectedIndex(0)
+                } else {
+                  setMentionMenuOpen(false)
                 }
               }}
               onKeyDown={handleKeyDown}

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -178,9 +178,10 @@ export interface NotificationConfig {
 
 // Global layout preferences (panel sizes and visibility)
 export interface LayoutConfig {
-  sidebarOpen?: boolean;          // Whether conversation list sidebar is open
-  sidebarWidth?: number;          // Conversation list sidebar width (px)
-  artifactRailWidth?: number;     // Artifact rail panel width (px)
+  sidebarOpen?: boolean;                 // Whether conversation list sidebar is open
+  sidebarWidth?: number;                 // Conversation list sidebar width (px)
+  sidebarTopSectionHeight?: number;      // Height of the top conversation sidebar section (px)
+  artifactRailWidth?: number;            // Artifact rail panel width (px)
 }
 
 export interface HaloConfig {
@@ -371,6 +372,7 @@ export interface Artifact {
   name: string;
   type: ArtifactType;
   path: string;
+  relativePath: string;
   extension: string;
   icon: string;
   createdAt: string;

--- a/src/shared/constants/ignore-patterns.ts
+++ b/src/shared/constants/ignore-patterns.ts
@@ -100,7 +100,7 @@ export const BASELINE_IGNORE_PATTERNS = [
   // ── C# / .NET ──
   // NOTE: 'bin' removed - too generic, could be user scripts directory
   'obj',
-  'packages',      // NuGet (older projects)
+  // NOTE: 'packages' removed - too generic for modern monorepos where it often stores source code
 
   // ── C / C++ ──
   'cmake-build-*',


### PR DESCRIPTION
## Summary

This PR improves several frontend interaction flows around artifacts and conversation navigation.

### What changed

- stop treating `packages` as a globally ignored directory so monorepo source folders can appear in the artifact browser
- add artifact relative-path support across the stack, including IPC, preload, renderer API, and shared types
- add right-click actions in artifact tree/card views to copy relative paths
- support dragging files and folders from the artifact panel into the chat input to insert backtick-wrapped relative path references
- add `@`-based artifact reference suggestions in the chat input with fuzzy path-prefix matching such as `@.cla/`
- add a resizable top section in the conversation sidebar and persist the layout setting

### Why

These changes make the right-side file panel more complete and more useful during prompting, while also improving navigation efficiency in the left conversation sidebar.

## Notes

- the branch currently still has local uncommitted lockfile changes in `package-lock.json` and `yarn.lock`, but they are not included in this PR commit
- the pushed commit for this PR is:
  - `68968d4 feat: improve artifact references and sidebar resizing interactions`
