### PR TITLE
Dereference $ref/$defs in tool schemas for strict endpoints

### DIFF
--- a/src/main/openai-compat-router/converters/tools.ts
+++ b/src/main/openai-compat-router/converters/tools.ts
@@ -22,55 +22,100 @@ import type {
 
 type JsonSchemaNode = Record<string, unknown>
 
+/** Maximum recursion depth as defense-in-depth against pathological schemas. */
+const DEREFERENCE_MAX_DEPTH = 64
+
 /**
- * Recursively resolve all $ref/#/$defs/... references within a JSON Schema node,
- * inlining the referenced definitions so the resulting schema contains no $ref
- * or $defs. This is required for strict OpenAI-compatible endpoints (e.g. Kimi /
- * Moonshot) that reject schemas containing $ref.
+ * Local-ref forms accepted by `resolveLocalRef`:
+ *   - `#/$defs/<Name>`        (JSON Schema 2019-09+ — what MCP servers typically emit)
+ *   - `#/definitions/<Name>`  (legacy Draft 4-7 form, still common)
  *
- * Only handles the local-reference form: "#/$defs/<Name>".
- * External $refs (URLs, file paths) are left untouched.
+ * External refs (URLs, file paths) are left untouched.
+ */
+function resolveLocalRef(
+  ref: string,
+  defs: Record<string, unknown>,
+  legacyDefs: Record<string, unknown>
+): unknown | undefined {
+  if (ref.startsWith('#/$defs/')) {
+    return defs[ref.slice('#/$defs/'.length)]
+  }
+  if (ref.startsWith('#/definitions/')) {
+    return legacyDefs[ref.slice('#/definitions/'.length)]
+  }
+  return undefined
+}
+
+/**
+ * Recursively resolve all local $ref pointers within a JSON Schema node,
+ * inlining the referenced definitions so the resulting schema contains no
+ * $ref / $defs / definitions. Required for strict OpenAI-compatible
+ * endpoints (e.g. Kimi / Moonshot) that reject schemas with $ref.
+ *
+ * Cycle protection: when a $ref is being expanded, its pointer is added to
+ * `seenRefs`. A nested $ref to the same target is replaced with `{}` (an
+ * unconstrained schema), which preserves request validity while breaking
+ * the cycle. Depth is also bounded as a hard safety net.
  */
 function dereferenceSchema(
   node: unknown,
-  defs: Record<string, unknown>
+  defs: Record<string, unknown>,
+  legacyDefs: Record<string, unknown>,
+  seenRefs: Set<string>,
+  depth: number
 ): unknown {
+  if (depth > DEREFERENCE_MAX_DEPTH) return {}
   if (node === null || typeof node !== 'object') return node
-  if (Array.isArray(node)) return node.map(item => dereferenceSchema(item, defs))
+  if (Array.isArray(node)) {
+    return node.map(item => dereferenceSchema(item, defs, legacyDefs, seenRefs, depth + 1))
+  }
 
   const obj = node as JsonSchemaNode
 
   // Resolve $ref before processing other keys
   if (typeof obj['$ref'] === 'string') {
     const ref = obj['$ref'] as string
-    if (ref.startsWith('#/$defs/')) {
-      const defName = ref.slice('#/$defs/'.length)
-      const target = defs[defName]
-      if (target != null) return dereferenceSchema(target, defs)
+    if (seenRefs.has(ref)) {
+      // Cycle detected — return an unconstrained schema to break the loop.
+      // This is safer than returning the raw $ref (which strict endpoints
+      // would reject) and won't crash the request.
+      return {}
     }
+    const target = resolveLocalRef(ref, defs, legacyDefs)
+    if (target != null) {
+      seenRefs.add(ref)
+      const resolved = dereferenceSchema(target, defs, legacyDefs, seenRefs, depth + 1)
+      seenRefs.delete(ref)
+      return resolved
+    }
+    // External or unresolvable ref — leave it intact for the caller to handle.
     return obj
   }
 
   const result: JsonSchemaNode = {}
   for (const [key, value] of Object.entries(obj)) {
-    if (key === '$defs') continue  // strip $defs from output
-    result[key] = dereferenceSchema(value, defs)
+    // Strip definition containers from output — they're inlined now
+    if (key === '$defs' || key === 'definitions') continue
+    result[key] = dereferenceSchema(value, defs, legacyDefs, seenRefs, depth + 1)
   }
   return result
 }
 
 /**
  * Return a parameters object safe for strict OpenAI-compatible endpoints.
- * If the input_schema contains $defs / $ref, all references are inlined
- * so that the resulting object is self-contained.
+ * If the input_schema contains $defs / definitions / $ref, all references
+ * are inlined so that the resulting object is self-contained.
  */
-function toOpenAIParameters(schema: AnthropicTool['input_schema']): JsonSchemaNode {
+export function toOpenAIParameters(schema: AnthropicTool['input_schema']): JsonSchemaNode {
   const raw = schema as unknown as JsonSchemaNode | undefined
   if (!raw) return { type: 'object', properties: {} }
 
-  const hasDefs = typeof raw['$defs'] === 'object' && raw['$defs'] !== null
-  if (!hasDefs) {
-    // Fast-path: no $defs, keep existing shape
+  const defs = (raw['$defs'] as Record<string, unknown> | undefined) ?? {}
+  const legacyDefs = (raw['definitions'] as Record<string, unknown> | undefined) ?? {}
+  const hasAnyDefs = Object.keys(defs).length > 0 || Object.keys(legacyDefs).length > 0
+
+  if (!hasAnyDefs) {
+    // Fast-path: no definition containers, keep existing shape
     return {
       type: 'object',
       properties: (raw['properties'] as JsonSchemaNode) || {},
@@ -78,8 +123,7 @@ function toOpenAIParameters(schema: AnthropicTool['input_schema']): JsonSchemaNo
     }
   }
 
-  const defs = raw['$defs'] as Record<string, unknown>
-  return dereferenceSchema(raw, defs) as JsonSchemaNode
+  return dereferenceSchema(raw, defs, legacyDefs, new Set(), 0) as JsonSchemaNode
 }
 
 // ============================================================================

--- a/src/main/openai-compat-router/converters/tools.ts
+++ b/src/main/openai-compat-router/converters/tools.ts
@@ -17,6 +17,72 @@ import type {
 } from '../types'
 
 // ============================================================================
+// Schema Dereferencing
+// ============================================================================
+
+type JsonSchemaNode = Record<string, unknown>
+
+/**
+ * Recursively resolve all $ref/#/$defs/... references within a JSON Schema node,
+ * inlining the referenced definitions so the resulting schema contains no $ref
+ * or $defs. This is required for strict OpenAI-compatible endpoints (e.g. Kimi /
+ * Moonshot) that reject schemas containing $ref.
+ *
+ * Only handles the local-reference form: "#/$defs/<Name>".
+ * External $refs (URLs, file paths) are left untouched.
+ */
+function dereferenceSchema(
+  node: unknown,
+  defs: Record<string, unknown>
+): unknown {
+  if (node === null || typeof node !== 'object') return node
+  if (Array.isArray(node)) return node.map(item => dereferenceSchema(item, defs))
+
+  const obj = node as JsonSchemaNode
+
+  // Resolve $ref before processing other keys
+  if (typeof obj['$ref'] === 'string') {
+    const ref = obj['$ref'] as string
+    if (ref.startsWith('#/$defs/')) {
+      const defName = ref.slice('#/$defs/'.length)
+      const target = defs[defName]
+      if (target != null) return dereferenceSchema(target, defs)
+    }
+    return obj
+  }
+
+  const result: JsonSchemaNode = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === '$defs') continue  // strip $defs from output
+    result[key] = dereferenceSchema(value, defs)
+  }
+  return result
+}
+
+/**
+ * Return a parameters object safe for strict OpenAI-compatible endpoints.
+ * If the input_schema contains $defs / $ref, all references are inlined
+ * so that the resulting object is self-contained.
+ */
+function toOpenAIParameters(schema: AnthropicTool['input_schema']): JsonSchemaNode {
+  const raw = schema as unknown as JsonSchemaNode | undefined
+  if (!raw) return { type: 'object', properties: {} }
+
+  const hasDefs = typeof raw['$defs'] === 'object' && raw['$defs'] !== null
+  if (!hasDefs) {
+    // Fast-path: no $defs, keep existing shape
+    return {
+      type: 'object',
+      properties: (raw['properties'] as JsonSchemaNode) || {},
+      ...(raw['required'] !== undefined ? { required: raw['required'] } : {}),
+    }
+  }
+
+  const defs = raw['$defs'] as Record<string, unknown>
+  return dereferenceSchema(raw, defs) as JsonSchemaNode
+}
+
+// ============================================================================
 // Tool Definition Conversion
 // ============================================================================
 
@@ -29,11 +95,7 @@ export function anthropicToolToOpenAIChatTool(tool: AnthropicTool): OpenAIChatTo
     function: {
       name: tool.name,
       description: tool.description || '',
-      parameters: {
-        type: 'object',
-        properties: tool.input_schema?.properties || {},
-        required: tool.input_schema?.required
-      },
+      parameters: toOpenAIParameters(tool.input_schema),
       strict: tool.strict
     }
   }
@@ -48,11 +110,7 @@ export function anthropicToolToResponsesTool(tool: AnthropicTool): OpenAIRespons
     type: 'function',
     name: tool.name,
     description: tool.description || '',
-    parameters: {
-      type: 'object',
-      properties: tool.input_schema?.properties || {},
-      required: tool.input_schema?.required
-    },
+    parameters: toOpenAIParameters(tool.input_schema),
     strict: tool.strict
   }
 }

--- a/src/renderer/components/settings/MessageChannelsSection.tsx
+++ b/src/renderer/components/settings/MessageChannelsSection.tsx
@@ -876,6 +876,17 @@ function PermissionSection({ instance, onChange, onDebouncedChange, permissionDe
             </div>
           )}
 
+          {/* Guest section divider — makes the owner/guest boundary visually explicit */}
+          {hasOwners && (
+            <div className="flex items-center gap-2 pt-1">
+              <div className="flex-1 border-t border-border/60" />
+              <span className="text-[10px] uppercase tracking-widest text-muted-foreground/50 px-1">
+                {t('Guest Permissions')}
+              </span>
+              <div className="flex-1 border-t border-border/60" />
+            </div>
+          )}
+
           {/* Guest access toggle (only when owners are set) */}
           {hasOwners && (
             <>
@@ -884,8 +895,8 @@ function PermissionSection({ instance, onChange, onDebouncedChange, permissionDe
                   <p className="text-sm text-muted-foreground">{t('Guest Access')}</p>
                   <p className="text-xs text-muted-foreground/70">
                     {guestAccessEnabled
-                      ? t('Guests have limited access')
-                      : t('Guests have no access')}
+                      ? t('Guests have limited access to selected tools below')
+                      : t('Guests have no tool access — chat only')}
                   </p>
                 </div>
                 <label className="relative inline-flex items-center cursor-pointer">

--- a/tests/unit/services/tools-dereference.test.ts
+++ b/tests/unit/services/tools-dereference.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit Tests for tool schema $ref/$defs dereferencing.
+ *
+ * Background: some MCP servers return tool inputSchemas that use JSON Schema
+ * $ref/$defs (or legacy `definitions`). Strict OpenAI-compatible endpoints
+ * (e.g. Kimi / Moonshot) reject schemas containing $ref. The converter must
+ * inline these references before forwarding the request.
+ *
+ * See issue #97.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  toOpenAIParameters,
+  anthropicToolToOpenAIChatTool,
+  anthropicToolToResponsesTool,
+} from '../../../src/main/openai-compat-router/converters/tools'
+import type { AnthropicTool } from '../../../src/main/openai-compat-router/types'
+
+// Helper — cast a plain object as AnthropicTool['input_schema'] for tests.
+// Schemas in production come from external MCP servers, so they often have
+// shapes that exceed the static type's narrow surface (e.g. $defs at root).
+const schema = (s: Record<string, unknown>) => s as unknown as AnthropicTool['input_schema']
+
+describe('toOpenAIParameters — fast-path (no $defs)', () => {
+  it('preserves type/properties/required for a plain schema', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    }))
+    expect(result).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    })
+  })
+
+  it('omits `required` when the input has none', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    }))
+    expect(result).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    })
+    expect(result).not.toHaveProperty('required')
+  })
+
+  it('returns an empty object schema for null/undefined input', () => {
+    expect(toOpenAIParameters(undefined as unknown as AnthropicTool['input_schema']))
+      .toEqual({ type: 'object', properties: {} })
+  })
+})
+
+describe('toOpenAIParameters — $defs dereferencing', () => {
+  it('inlines a single $ref and strips $defs from the output', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        record: { $ref: '#/$defs/Record' },
+      },
+      required: ['record'],
+      $defs: {
+        Record: {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+        },
+      },
+    }))
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        record: {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+        },
+      },
+      required: ['record'],
+    })
+    expect(result).not.toHaveProperty('$defs')
+    // Reproduces the exact pattern that broke Kimi: schema must be free of $ref
+    expect(JSON.stringify(result)).not.toContain('$ref')
+  })
+
+  it('inlines $ref inside an array `items` schema', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        records: {
+          type: 'array',
+          items: { $ref: '#/$defs/Row' },
+        },
+      },
+      $defs: {
+        Row: { type: 'object', properties: { v: { type: 'number' } } },
+      },
+    }))
+
+    expect((result.properties as Record<string, unknown>).records).toEqual({
+      type: 'array',
+      items: { type: 'object', properties: { v: { type: 'number' } } },
+    })
+  })
+
+  it('resolves nested $refs (def referencing another def)', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        outer: { $ref: '#/$defs/Outer' },
+      },
+      $defs: {
+        Outer: {
+          type: 'object',
+          properties: { inner: { $ref: '#/$defs/Inner' } },
+        },
+        Inner: { type: 'string' },
+      },
+    }))
+
+    expect(result.properties).toEqual({
+      outer: {
+        type: 'object',
+        properties: { inner: { type: 'string' } },
+      },
+    })
+  })
+
+  it('resolves the same $ref reused at multiple sites', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        a: { $ref: '#/$defs/Item' },
+        b: { $ref: '#/$defs/Item' },
+      },
+      $defs: {
+        Item: { type: 'string', description: 'shared' },
+      },
+    }))
+
+    expect(result.properties).toEqual({
+      a: { type: 'string', description: 'shared' },
+      b: { type: 'string', description: 'shared' },
+    })
+  })
+})
+
+describe('toOpenAIParameters — legacy `definitions` keyword', () => {
+  it('inlines #/definitions/<Name> refs (Draft 4-7 style)', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        item: { $ref: '#/definitions/Item' },
+      },
+      definitions: {
+        Item: { type: 'string' },
+      },
+    }))
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: { item: { type: 'string' } },
+    })
+    expect(result).not.toHaveProperty('definitions')
+  })
+})
+
+describe('toOpenAIParameters — cycle protection', () => {
+  it('does not infinite-loop on a self-referencing schema', () => {
+    // Tree node: { value, children: TreeNode[] } — a real-world cycle.
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        root: { $ref: '#/$defs/Node' },
+      },
+      $defs: {
+        Node: {
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+            children: {
+              type: 'array',
+              items: { $ref: '#/$defs/Node' },  // ← cycle
+            },
+          },
+        },
+      },
+    }))
+
+    // The first level expands; the cycle resolves to an unconstrained
+    // schema ({}) which strict endpoints accept.
+    expect(result.properties).toBeDefined()
+    const root = (result.properties as Record<string, unknown>).root as Record<string, unknown>
+    expect(root.type).toBe('object')
+    const props = root.properties as Record<string, unknown>
+    expect(props.value).toEqual({ type: 'string' })
+    const children = props.children as Record<string, unknown>
+    expect(children.type).toBe('array')
+    // The recursive position is broken — items resolves to {} not another $ref
+    expect(children.items).toEqual({})
+    expect(JSON.stringify(result)).not.toContain('$ref')
+  })
+
+  it('does not infinite-loop on a mutual A→B→A cycle', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: { a: { $ref: '#/$defs/A' } },
+      $defs: {
+        A: { type: 'object', properties: { b: { $ref: '#/$defs/B' } } },
+        B: { type: 'object', properties: { a: { $ref: '#/$defs/A' } } },
+      },
+    }))
+
+    expect(JSON.stringify(result)).not.toContain('$ref')
+  })
+})
+
+describe('toOpenAIParameters — unresolvable refs', () => {
+  it('leaves external refs intact (URL ref, no $defs to resolve)', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        ext: { $ref: 'https://example.com/schema.json' },
+      },
+      $defs: {
+        Other: { type: 'string' },
+      },
+    }))
+
+    // External refs cannot be inlined; preserved as-is so the upstream
+    // endpoint can decide how to handle them.
+    expect((result.properties as Record<string, unknown>).ext)
+      .toEqual({ $ref: 'https://example.com/schema.json' })
+  })
+
+  it('leaves a ref intact when the target name is missing from $defs', () => {
+    const result = toOpenAIParameters(schema({
+      type: 'object',
+      properties: {
+        x: { $ref: '#/$defs/Missing' },
+      },
+      $defs: {
+        Other: { type: 'string' },
+      },
+    }))
+
+    expect((result.properties as Record<string, unknown>).x)
+      .toEqual({ $ref: '#/$defs/Missing' })
+  })
+})
+
+describe('anthropicToolToOpenAIChatTool / anthropicToolToResponsesTool integration', () => {
+  it('produces a $ref-free Chat tool when input has $defs', () => {
+    const tool: AnthropicTool = {
+      name: 'smartsheet_add_records',
+      description: 'Add records to a sheet',
+      input_schema: schema({
+        type: 'object',
+        properties: { records: { $ref: '#/$defs/Row' } },
+        required: ['records'],
+        $defs: {
+          Row: { type: 'object', properties: { id: { type: 'string' } } },
+        },
+      }) as AnthropicTool['input_schema'],
+    }
+
+    const chatTool = anthropicToolToOpenAIChatTool(tool)
+    expect(chatTool.type).toBe('function')
+    expect(chatTool.function.name).toBe('smartsheet_add_records')
+    expect(JSON.stringify(chatTool.function.parameters)).not.toContain('$ref')
+    expect(JSON.stringify(chatTool.function.parameters)).not.toContain('$defs')
+
+    const responsesTool = anthropicToolToResponsesTool(tool)
+    expect(responsesTool.type).toBe('function')
+    expect(responsesTool.name).toBe('smartsheet_add_records')
+    expect(JSON.stringify(responsesTool.parameters)).not.toContain('$ref')
+    expect(JSON.stringify(responsesTool.parameters)).not.toContain('$defs')
+  })
+
+  it('keeps the existing fast-path shape for tools without $defs', () => {
+    const tool: AnthropicTool = {
+      name: 'simple_tool',
+      description: 'Plain tool',
+      input_schema: {
+        type: 'object',
+        properties: { msg: { type: 'string' } },
+        required: ['msg'],
+      },
+    }
+
+    const chatTool = anthropicToolToOpenAIChatTool(tool)
+    expect(chatTool.function.parameters).toEqual({
+      type: 'object',
+      properties: { msg: { type: 'string' } },
+      required: ['msg'],
+    })
+  })
+})


### PR DESCRIPTION
## Related Issue
Fixes #97

## Changes
Added schema dereferencing to inline JSON Schema `$ref` and `$defs` (or legacy `definitions`) before forwarding tool schemas to strict OpenAI-compatible endpoints like Kimi/Moonshot that reject schemas containing `$ref`.

### Key additions:
- **`toOpenAIParameters()`**: New exported function that converts Anthropic tool input schemas to OpenAI-compatible parameters, with automatic dereferencing of local references
- **`dereferenceSchema()`**: Recursive helper that inlines all `$ref` pointers and strips definition containers from the schema
- **`resolveLocalRef()`**: Resolves both modern (`#/$defs/<Name>`) and legacy (`#/definitions/<Name>`) reference formats
- **Cycle protection**: Detects and breaks reference cycles (e.g., tree nodes with recursive children) by replacing cyclic references with `{}`, preventing infinite loops while maintaining schema validity
- **Fast-path optimization**: Schemas without definitions skip dereferencing entirely

### Integration:
- `anthropicToolToOpenAIChatTool()` and `anthropicToolToResponsesTool()` now use `toOpenAIParameters()` instead of manually extracting properties/required fields

### UI improvements:
- Added visual divider in permission settings to clarify owner/guest boundary
- Improved guest access toggle descriptions for clarity

## Testing
- Added comprehensive unit test suite (`tools-dereference.test.ts`) covering:
  - Fast-path behavior for schemas without definitions
  - Single and nested `$ref` resolution
  - Reused references across multiple properties
  - Legacy `definitions` keyword support
  - Self-referencing and mutual cycle detection
  - External and unresolvable reference handling
  - Integration with `anthropicToolToOpenAIChatTool()` and `anthropicToolToResponsesTool()`
- All tests pass with `npm run test:unit`

https://claude.ai/code/session_01UyYkDaN212bouJH68MmzxG