### PR TITLE
Android status bar overlap fix on MIUI 14 (integration of #101)

### DIFF
--- a/android/app/src/main/java/com/halo/mobile/MainActivity.java
+++ b/android/app/src/main/java/com/halo/mobile/MainActivity.java
@@ -2,14 +2,24 @@ package com.halo.mobile;
 
 import android.os.Build;
 import android.os.Bundle;
-import android.view.View;
 import android.webkit.WebView;
 import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
+
+    /**
+     * Bridge / WebView readiness retry budget for safe-area injection.
+     * 10 attempts × 200 ms = up to 2 s. If the WebView is not ready by then
+     * we give up — the JS-side fallbacks (Capacitor SystemBars on Android 16+,
+     * or the renderer's visualViewport listener) will still set the variable
+     * later when the page actually mounts.
+     */
+    private static final int SAFE_AREA_RETRY_MAX = 10;
+    private static final long SAFE_AREA_RETRY_DELAY_MS = 200L;
+
+    /** Default status bar height assumption (24dp) when all measurements fail. */
+    private static final int DEFAULT_STATUS_BAR_DP = 24;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -29,29 +39,32 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void injectSafeAreaInsets() {
-        // Use a retrying handler since the WebView may not be ready immediately
         getWindow().getDecorView().post(new Runnable() {
+            private int attempts = 0;
+
             @Override
             public void run() {
                 if (bridge == null || bridge.getWebView() == null) {
-                    // WebView not ready yet — retry after a short delay
-                    getWindow().getDecorView().postDelayed(this, 200);
+                    if (++attempts >= SAFE_AREA_RETRY_MAX) {
+                        // Give up. Renderer-side fallbacks (visualViewport listener,
+                        // Capacitor SystemBars on Android 16+) will still recover.
+                        android.util.Log.w("Halo", "Safe-area injection skipped: WebView not ready after "
+                                + SAFE_AREA_RETRY_MAX + " attempts");
+                        return;
+                    }
+                    getWindow().getDecorView().postDelayed(this, SAFE_AREA_RETRY_DELAY_MS);
                     return;
                 }
 
                 int statusBarHeightPx = getStatusBarHeight();
-                if (statusBarHeightPx <= 0) {
-                    // Fallback: 48px is a reasonable default for ~24dp @ 2x density
-                    statusBarHeightPx = 48;
-                }
-
                 float density = getResources().getDisplayMetrics().density;
                 int statusBarDp = Math.round(statusBarHeightPx / density);
 
                 WebView webView = bridge.getWebView();
-                String script = "try {" +
-                        "document.documentElement.style.setProperty('--safe-area-inset-top', '" + statusBarDp + "px');" +
-                        "} catch(e) { console.error('safe-area-inset-top injection failed:', e); }";
+                String script = "try {"
+                        + "document.documentElement.style.setProperty('--safe-area-inset-top', '"
+                        + statusBarDp + "px');"
+                        + "} catch(e) { console.warn('safe-area-inset-top injection failed:', e); }";
                 webView.evaluateJavascript(script, null);
             }
         });
@@ -70,11 +83,12 @@ public class MainActivity extends BridgeActivity {
         // Method 2: Get from Android resource system (works on all API levels)
         int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
         if (resourceId > 0) {
-            return getResources().getDimensionPixelSize(resourceId);
+            int px = getResources().getDimensionPixelSize(resourceId);
+            if (px > 0) return px;
         }
 
         // Method 3: Fallback - compute from display metrics (~24dp)
         float density = getResources().getDisplayMetrics().density;
-        return Math.round(24 * density);
+        return Math.round(DEFAULT_STATUS_BAR_DP * density);
     }
 }

--- a/android/app/src/main/java/com/halo/mobile/MainActivity.java
+++ b/android/app/src/main/java/com/halo/mobile/MainActivity.java
@@ -1,7 +1,12 @@
 package com.halo.mobile;
 
+import android.os.Build;
 import android.os.Bundle;
-
+import android.view.View;
+import android.webkit.WebView;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
@@ -11,5 +16,65 @@ public class MainActivity extends BridgeActivity {
         // Register custom plugins before super.onCreate()
         registerPlugin(ForegroundServicePlugin.class);
         super.onCreate(savedInstanceState);
+
+        // Enable edge-to-edge display: let app content draw behind system bars
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+        // Inject status bar height as CSS variable for safe area padding.
+        // Capacitor's built-in SystemBars plugin only injects CSS variables
+        // on Android 16+ (VANILLA_ICE_CREAM). On earlier versions (including
+        // MIUI 14 / Android 13-14), we handle it here so CSS env(safe-area-inset-top)
+        // fallback (which returns 0 on Android WebView) is replaced with real values.
+        injectSafeAreaInsets();
+    }
+
+    private void injectSafeAreaInsets() {
+        // Use a retrying handler since the WebView may not be ready immediately
+        getWindow().getDecorView().post(new Runnable() {
+            @Override
+            public void run() {
+                if (bridge == null || bridge.getWebView() == null) {
+                    // WebView not ready yet — retry after a short delay
+                    getWindow().getDecorView().postDelayed(this, 200);
+                    return;
+                }
+
+                int statusBarHeightPx = getStatusBarHeight();
+                if (statusBarHeightPx <= 0) {
+                    // Fallback: 48px is a reasonable default for ~24dp @ 2x density
+                    statusBarHeightPx = 48;
+                }
+
+                float density = getResources().getDisplayMetrics().density;
+                int statusBarDp = Math.round(statusBarHeightPx / density);
+
+                WebView webView = bridge.getWebView();
+                String script = "try {" +
+                        "document.documentElement.style.setProperty('--safe-area-inset-top', '" + statusBarDp + "px');" +
+                        "} catch(e) { console.error('safe-area-inset-top injection failed:', e); }";
+                webView.evaluateJavascript(script, null);
+            }
+        });
+    }
+
+    private int getStatusBarHeight() {
+        // Method 1: Get from WindowInsets (most accurate, requires API 30+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            android.view.WindowInsets insets = getWindow().getDecorView().getRootWindowInsets();
+            if (insets != null) {
+                int topInset = insets.getInsets(android.view.WindowInsets.Type.statusBars()).top;
+                if (topInset > 0) return topInset;
+            }
+        }
+
+        // Method 2: Get from Android resource system (works on all API levels)
+        int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return getResources().getDimensionPixelSize(resourceId);
+        }
+
+        // Method 3: Fallback - compute from display metrics (~24dp)
+        float density = getResources().getDisplayMetrics().density;
+        return Math.round(24 * density);
     }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,11 +2,17 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <!-- Enable edge-to-edge: draw behind system bars -->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Base application theme. -->
+    <!-- Base application theme.
+
+         Parent: Theme.AppCompat.DayNight.NoActionBar
+         - DayNight: app already supports light/dark via WebView CSS, so the
+           native theme should follow system mode (matches AppTheme.NoActionBar
+           below, which the activity actually renders into after splash).
+         - NoActionBar: this is a Capacitor WebView app — the native ActionBar
+           is never shown.
+
+         The transparent status/navigation bar items below enable edge-to-edge:
+         the WebView paints behind both system bars, and `MainActivity` writes
+         the real status bar height into `--safe-area-inset-top` so layouts
+         using `var(--sat)` push content below it. -->
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <!-- Enable edge-to-edge: draw behind system bars -->
+        <!-- Edge-to-edge: draw behind system bars; safe-area handled in WebView. -->
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx2048m
 
 # JDK 21 is required by capacitor-android.
 # Point Gradle to the correct JDK (install: brew install openjdk@21)
-org.gradle.java.home=/opt/homebrew/opt/openjdk@21
+org.gradle.java.home=C\:\\tools\\Java\\JavaJDK
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx2048m
 
 # JDK 21 is required by capacitor-android.
 # Point Gradle to the correct JDK (install: brew install openjdk@21)
-org.gradle.java.home=C\:\\tools\\Java\\JavaJDK
+org.gradle.java.home=/opt/homebrew/opt/openjdk@21
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -33,6 +33,8 @@ const config: CapacitorConfig = {
     }
   },
   android: {
+    // Enable edge-to-edge display to prevent statusbar overlap
+    edgeToEdge: true,
     // Allow cleartext traffic for LAN connections (http://)
     allowMixedContent: true,
     // Background mode: keep WebSocket alive

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -28,7 +28,7 @@ import { UpdateNotification } from './components/updater/UpdateNotification'
 import { NotificationToast } from './components/notification/NotificationToast'
 import { useNotificationStore } from './stores/notification.store'
 import { api } from './api'
-import { StatusBar } from '@capacitor/status-bar';
+import { syncStatusBarStyle } from './api/safe-area'
 import { isCapacitor, isElectron } from './api/transport'
 import { useTelemetry } from './hooks/useTelemetry'
 import type { WsConnectionState } from './api/transport'
@@ -217,22 +217,22 @@ export default function App() {
     const theme = config?.appearance?.theme || 'dark'
     applyTheme(theme)
 
+    // Resolve effective dark/light for the status bar.
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const isDark = theme === 'dark' || (theme === 'system' && systemPrefersDark)
+
+    // Sync status bar style with theme (Capacitor mobile only). No-op elsewhere.
+    void syncStatusBarStyle(isDark)
+
     // Listen for system theme changes when using 'system' mode
     if (theme === 'system') {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-      const handleChange = () => applyTheme('system')
+      const handleChange = () => {
+        applyTheme('system')
+        void syncStatusBarStyle(mediaQuery.matches)
+      }
       mediaQuery.addEventListener('change', handleChange)
       return () => mediaQuery.removeEventListener('change', handleChange)
-    }
-
-    // Sync status bar style with theme (Capacitor mobile only)
-    if (api.isCapacitorMode()) {
-      try {
-        const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-        StatusBar.setStyle({ style: isDark ? 'DARK' : 'LIGHT' });
-      } catch {
-        // ignore
-      }
     }
   }, [config?.appearance?.theme])
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -28,6 +28,7 @@ import { UpdateNotification } from './components/updater/UpdateNotification'
 import { NotificationToast } from './components/notification/NotificationToast'
 import { useNotificationStore } from './stores/notification.store'
 import { api } from './api'
+import { StatusBar } from '@capacitor/status-bar';
 import { isCapacitor, isElectron } from './api/transport'
 import { useTelemetry } from './hooks/useTelemetry'
 import type { WsConnectionState } from './api/transport'
@@ -222,6 +223,16 @@ export default function App() {
       const handleChange = () => applyTheme('system')
       mediaQuery.addEventListener('change', handleChange)
       return () => mediaQuery.removeEventListener('change', handleChange)
+    }
+
+    // Sync status bar style with theme (Capacitor mobile only)
+    if (api.isCapacitorMode()) {
+      try {
+        const isDark = theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        StatusBar.setStyle({ style: isDark ? 'DARK' : 'LIGHT' });
+      } catch {
+        // ignore
+      }
     }
   }, [config?.appearance?.theme])
 

--- a/src/renderer/api/safe-area.ts
+++ b/src/renderer/api/safe-area.ts
@@ -1,0 +1,106 @@
+/**
+ * Capacitor Mobile Shell — Status Bar & Safe Area
+ *
+ * Initializes edge-to-edge display and safe-area inset variables for the
+ * Capacitor (Android) build. The page renders behind the status bar; the
+ * `--safe-area-inset-top` CSS variable carries the real status bar height
+ * so layouts using `var(--sat)` (see `globals.css`) push content below it.
+ *
+ * Source-of-truth strategy (single layer, no JS polling):
+ *   1. Native `MainActivity` writes `--safe-area-inset-top` once on app
+ *      start via `WebView.evaluateJavascript`. This is deterministic and
+ *      runs before React mounts.
+ *   2. Capacitor 8's built-in SystemBars plugin writes the same variable on
+ *      Android 16+ (no-op on older versions). Either source is fine — both
+ *      target the same custom property.
+ *   3. A `visualViewport.resize` listener keeps the variable in sync when
+ *      the keyboard opens / device rotates.
+ *
+ * No-ops in Electron/Web: Capacitor checks short-circuit before any work.
+ */
+
+import { isCapacitor } from './transport'
+
+type StatusBarStyle = 'DARK' | 'LIGHT'
+
+let _statusBarPlugin: typeof import('@capacitor/status-bar').StatusBar | null = null
+let _statusBarLoadAttempted = false
+
+async function loadStatusBar(): Promise<typeof import('@capacitor/status-bar').StatusBar | null> {
+  if (_statusBarPlugin) return _statusBarPlugin
+  if (_statusBarLoadAttempted) return null
+  _statusBarLoadAttempted = true
+
+  try {
+    const mod = await import('@capacitor/status-bar')
+    _statusBarPlugin = mod.StatusBar
+    return _statusBarPlugin
+  } catch (err) {
+    console.warn('[SafeArea] @capacitor/status-bar unavailable:', err)
+    return null
+  }
+}
+
+/**
+ * One-time mobile shell init. Safe to call before React mounts.
+ * - Enables edge-to-edge (overlay WebView)
+ * - Wires the `visualViewport.resize` listener that re-syncs `--safe-area-inset-top`
+ *   when the keyboard opens or the device rotates.
+ *
+ * Status bar text style (DARK/LIGHT) is intentionally NOT set here — the
+ * theme effect in `App.tsx` calls `syncStatusBarStyle()` once the theme
+ * config has loaded. Setting an eager default here would cause a flicker
+ * for users on a different theme.
+ */
+export async function initCapacitorMobileShell(): Promise<void> {
+  if (!isCapacitor()) return
+
+  const StatusBar = await loadStatusBar()
+  if (!StatusBar) return
+
+  try {
+    await StatusBar.setOverlaysWebView({ overlay: true })
+  } catch (err) {
+    console.warn('[SafeArea] setOverlaysWebView failed:', err)
+  }
+
+  installViewportResizeListener()
+}
+
+/**
+ * Sync status bar text style (DARK = dark text on light bg, LIGHT = light
+ * text on dark bg) with the app theme. Call from the App's theme effect.
+ */
+export async function syncStatusBarStyle(isDark: boolean): Promise<void> {
+  if (!isCapacitor()) return
+
+  const StatusBar = await loadStatusBar()
+  if (!StatusBar) return
+
+  const style: StatusBarStyle = isDark ? 'DARK' : 'LIGHT'
+  try {
+    await StatusBar.setStyle({ style: style as never })
+  } catch (err) {
+    console.warn('[SafeArea] setStyle failed:', err)
+  }
+}
+
+let _viewportListenerInstalled = false
+
+function installViewportResizeListener(): void {
+  if (_viewportListenerInstalled) return
+  if (typeof window === 'undefined' || !window.visualViewport) return
+  _viewportListenerInstalled = true
+
+  const sync = () => {
+    const offsetTop = window.visualViewport?.offsetTop ?? 0
+    if (offsetTop > 0) {
+      document.documentElement.style.setProperty(
+        '--safe-area-inset-top',
+        offsetTop + 'px'
+      )
+    }
+  }
+
+  window.visualViewport.addEventListener('resize', sync)
+}

--- a/src/renderer/components/artifact/ArtifactRail.tsx
+++ b/src/renderer/components/artifact/ArtifactRail.tsx
@@ -517,7 +517,7 @@ export function ArtifactRail({
 
         {/* Overlay backdrop + panel - z-[70] to stay above Canvas overlay (z-50) */}
         {mobileOverlayOpen && (
-          <div className="fixed inset-0 z-[70] flex justify-end">
+          <div className="fixed z-[70] flex justify-end" style={{ top: 'var(--sat, 0px)', right: 0, bottom: 0, left: 0 }}>
             {/* Backdrop */}
             <div
               className="absolute inset-0 bg-background/70 animate-fade-in"

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -19,6 +19,99 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
 
+
+// ========================================
+// CAPACITOR INITIALIZATION (mobile only)
+// ========================================
+// Initialize status bar for edge-to-edge display on Android.
+// Runs eagerly to prevent status bar overlap before React mounts.
+void (async () => {
+  try {
+    const Capacitor = (await import('@capacitor/core')).Capacitor;
+    if (Capacitor.isNativePlatform()) {
+      const { StatusBar } = await import('@capacitor/status-bar');
+      await StatusBar.setOverlaysWebView({ overlay: true });
+      await StatusBar.setStyle({ style: 'DARK' });
+
+      // Fallback: ensure safe-area-inset-top CSS variable is set.
+      // Capacitor's SystemBars plugin only injects it on Android 16+.
+      // On older Android (MIUI 14 = Android 13-14), it's never set.
+      // The native MainActivity.java also injects it, but this JS
+      // fallback ensures it's set if native injection races or fails.
+      await ensureSafeAreaTop();
+    }
+  } catch {
+    // Non-Capacitor environments: silently ignore
+  }
+})();
+
+/** Ensure --safe-area-inset-top CSS variable reflects the real status bar height.
+ *
+ *  Primary source: window.visualViewport.offsetTop — this gives the actual
+ *  CSS-pixel offset from the screen top to the visual viewport, which matches
+ *  the status bar height on mobile. This avoids the common off-by-a-few-px
+ *  issues from Android resource-based status bar height calculations.
+ *
+ *  Native android injection (MainActivity.java) is the fallback — we prefer
+ *  the JS-measured value because it's exact for the device's actual UI chrome.
+ */
+async function ensureSafeAreaTop(): Promise<void> {
+  const setTop = (px: number) => {
+    if (px > 0) {
+      document.documentElement.style.setProperty('--safe-area-inset-top', px + 'px');
+    }
+  };
+
+  // Helper: read the current CSS variable value
+  const readCurrent = (): string =>
+    getComputedStyle(document.documentElement)
+      .getPropertyValue('--safe-area-inset-top').trim();
+
+  // 1) Wait a moment for the native injection to happen first (more accurate)
+  for (let i = 0; i < 5; i++) {
+    const v = readCurrent();
+    if (v && v !== '0px' && v !== '') return;
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  // 2) Use visualViewport.offsetTop as the primary measurement (real-time, exact)
+  const updateFromViewport = () => {
+    if (window.visualViewport && window.visualViewport.offsetTop > 0) {
+      setTop(window.visualViewport.offsetTop);
+      return true;
+    }
+    return false;
+  };
+
+  if (updateFromViewport()) return;
+
+  // 3) Last resort: the native injection may still arrive late,
+  //    or read from what the native code already set.
+  for (let i = 0; i < 5; i++) {
+    await new Promise(r => setTimeout(r, 300));
+    if (updateFromViewport()) return;
+
+    const v = readCurrent();
+    if (v && v !== '0px' && v !== '') return;
+  }
+
+  // 4) Ultimate fallback: ~24dp estimated from device pixel ratio
+  const dpr = window.devicePixelRatio || 2;
+  setTop(Math.round(24 * dpr));
+}
+
+// Keep safe-area-inset-top in sync when viewport changes (keyboard, rotation, etc.)
+if (window.visualViewport) {
+  window.visualViewport.addEventListener('resize', () => {
+    if (window.visualViewport.offsetTop > 0) {
+      document.documentElement.style.setProperty(
+        '--safe-area-inset-top',
+        window.visualViewport.offsetTop + 'px'
+      );
+    }
+  });
+}
+
 // i18n configuration - must be imported before App
 import './i18n'
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -18,99 +18,10 @@ if (typeof window !== 'undefined' && 'halo' in window) {
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { initCapacitorMobileShell } from './api/safe-area'
 
-
-// ========================================
-// CAPACITOR INITIALIZATION (mobile only)
-// ========================================
-// Initialize status bar for edge-to-edge display on Android.
-// Runs eagerly to prevent status bar overlap before React mounts.
-void (async () => {
-  try {
-    const Capacitor = (await import('@capacitor/core')).Capacitor;
-    if (Capacitor.isNativePlatform()) {
-      const { StatusBar } = await import('@capacitor/status-bar');
-      await StatusBar.setOverlaysWebView({ overlay: true });
-      await StatusBar.setStyle({ style: 'DARK' });
-
-      // Fallback: ensure safe-area-inset-top CSS variable is set.
-      // Capacitor's SystemBars plugin only injects it on Android 16+.
-      // On older Android (MIUI 14 = Android 13-14), it's never set.
-      // The native MainActivity.java also injects it, but this JS
-      // fallback ensures it's set if native injection races or fails.
-      await ensureSafeAreaTop();
-    }
-  } catch {
-    // Non-Capacitor environments: silently ignore
-  }
-})();
-
-/** Ensure --safe-area-inset-top CSS variable reflects the real status bar height.
- *
- *  Primary source: window.visualViewport.offsetTop — this gives the actual
- *  CSS-pixel offset from the screen top to the visual viewport, which matches
- *  the status bar height on mobile. This avoids the common off-by-a-few-px
- *  issues from Android resource-based status bar height calculations.
- *
- *  Native android injection (MainActivity.java) is the fallback — we prefer
- *  the JS-measured value because it's exact for the device's actual UI chrome.
- */
-async function ensureSafeAreaTop(): Promise<void> {
-  const setTop = (px: number) => {
-    if (px > 0) {
-      document.documentElement.style.setProperty('--safe-area-inset-top', px + 'px');
-    }
-  };
-
-  // Helper: read the current CSS variable value
-  const readCurrent = (): string =>
-    getComputedStyle(document.documentElement)
-      .getPropertyValue('--safe-area-inset-top').trim();
-
-  // 1) Wait a moment for the native injection to happen first (more accurate)
-  for (let i = 0; i < 5; i++) {
-    const v = readCurrent();
-    if (v && v !== '0px' && v !== '') return;
-    await new Promise(r => setTimeout(r, 200));
-  }
-
-  // 2) Use visualViewport.offsetTop as the primary measurement (real-time, exact)
-  const updateFromViewport = () => {
-    if (window.visualViewport && window.visualViewport.offsetTop > 0) {
-      setTop(window.visualViewport.offsetTop);
-      return true;
-    }
-    return false;
-  };
-
-  if (updateFromViewport()) return;
-
-  // 3) Last resort: the native injection may still arrive late,
-  //    or read from what the native code already set.
-  for (let i = 0; i < 5; i++) {
-    await new Promise(r => setTimeout(r, 300));
-    if (updateFromViewport()) return;
-
-    const v = readCurrent();
-    if (v && v !== '0px' && v !== '') return;
-  }
-
-  // 4) Ultimate fallback: ~24dp estimated from device pixel ratio
-  const dpr = window.devicePixelRatio || 2;
-  setTop(Math.round(24 * dpr));
-}
-
-// Keep safe-area-inset-top in sync when viewport changes (keyboard, rotation, etc.)
-if (window.visualViewport) {
-  window.visualViewport.addEventListener('resize', () => {
-    if (window.visualViewport.offsetTop > 0) {
-      document.documentElement.style.setProperty(
-        '--safe-area-inset-top',
-        window.visualViewport.offsetTop + 'px'
-      );
-    }
-  });
-}
+// Capacitor mobile shell — edge-to-edge + safe-area sync. No-op on Electron/Web.
+void initCapacitorMobileShell()
 
 // i18n configuration - must be imported before App
 import './i18n'


### PR DESCRIPTION
## Summary

Integrates community PR #101 (Android edge-to-edge + safe-area handling for MIUI 14 / Android 13-14) and applies follow-up cleanup.

This PR contains:
1. **Merge of #101** (community contribution from @DandelionRi) — preserves authorship via merge commit
2. **e6febfd refactor(android)** — review-driven cleanup (this commit)

Original problem statement and approach are intact; the cleanup commit only addresses code-quality issues found in review.

## What the cleanup commit changes

### Blocking fix
- `gradle.properties` — restore `org.gradle.java.home=/opt/homebrew/opt/openjdk@21` (PR overwrote it with a Windows-only absolute path that broke builds for everyone else)

### Architecture / quality
- Extract Capacitor mobile shell into **`src/renderer/api/safe-area.ts`** matching the existing `foreground-service.ts` convention. `main.tsx` drops 93 lines of inline platform code for a single `initCapacitorMobileShell()` call.
- Drop the JS-side polling cascade (was up to 2.5s of `setTimeout` racing the native injection). Single source of truth is now `MainActivity.injectSafeAreaInsets`; renderer keeps only the `visualViewport.resize` listener for keyboard/rotation.
- **App.tsx bug fix** — the original PR had an early-return that skipped `StatusBar.setStyle` when `theme === 'system'`. Status bar style now syncs in all theme modes and re-syncs on system colour scheme change.
- Remove eager `StatusBar.setStyle({ style: 'DARK' })` in `main.tsx` — App.tsx's theme effect is the single owner, avoiding a flicker for light-theme users.

### Robustness
- `MainActivity.injectSafeAreaInsets` — bound retry loop (10 × 200 ms instead of unbounded), warn on give-up. Renderer fallbacks still recover.
- `MainActivity` — drop unused `View` / `WindowInsetsCompat` / `WindowInsetsControllerCompat` imports.
- Replace silent `catch {}` blocks with `console.warn` so plugin failures are visible.

### Documentation
- `styles.xml` — comment block explaining the `Theme.AppCompat.Light.DarkActionBar` → `Theme.AppCompat.DayNight.NoActionBar` move (DayNight matches the WebView's existing light/dark support; NoActionBar matches actual usage).

## Verification
- `tsc --noEmit -p tsconfig.web.json` — no new errors introduced in touched files (`safe-area.ts`, `main.tsx`, `App.tsx`)
- Pre-existing TS errors unrelated to this change (Map iteration, Window.halo augmentation) are unchanged
- Behaviour change: the original PR's edge-to-edge + `--safe-area-inset-top` mechanism is preserved end-to-end (native injection → `--safe-area-inset-top` → existing `--sat` bridge in `globals.css:117` → `var(--sat)` consumers in components)

## Test plan
- [ ] Build APK: `npm run build:android:debug`
- [ ] Install on MIUI 14 / Android 13-14 device — status bar no longer overlaps content
- [ ] Toggle theme: `dark` / `light` / `system` — status bar text colour follows theme
- [ ] Open soft keyboard / rotate device — `--sat` stays correct
- [ ] Run mobile app via `npm run cap:run:android`
- [ ] Verify Electron desktop build still launches (`npm run dev`)

## Notes
- After this lands on `main`, the `android/statusbar-fix` branch can be deleted.
- Co-author: @DandelionRi (PR #101 commits preserved via merge)