### PR TITLE
fix(publish): align HTTP registry dispatcher with server Verdict/Report schema

### DIFF
--- a/src/main/store/publish/dispatchers/http-registry.ts
+++ b/src/main/store/publish/dispatchers/http-registry.ts
@@ -106,12 +106,17 @@ export async function dispatch(
   }
 
   // Server responses are not always JSON. http.Error sends text/plain.
+  // Shape matches server/internal/rules/runner.go Report/Verdict — field
+  // names here must track that struct (json tags) exactly.
   let body: {
     slug?: string
     version?: string
     verdict?: string
     comment?: string
-    report?: { overall?: string; rules?: Array<{ id: string; severity: string; message: string }> }
+    report?: {
+      overall?: string
+      verdicts?: Array<{ rule: string; severity: string; message: string; requires_human?: boolean }>
+    }
   } = {}
   let rawBody = ''
   const contentType = response.headers.get('content-type') ?? ''
@@ -127,9 +132,12 @@ export async function dispatch(
 
   if (!response.ok) {
     // Surface as much of the actual failure as possible.
-    const ruleSummary = body.report?.rules
-      ?.filter(r => r.severity === 'fail' || r.severity === 'error')
-      .map(r => `  - [${r.severity}] ${r.id}: ${r.message}`)
+    // Surface anything that isn't a clean pass, plus warn-level verdicts that
+    // tripped the human-review threshold — those are precisely the cases where
+    // the user needs to see why publish was blocked.
+    const ruleSummary = body.report?.verdicts
+      ?.filter(r => (r.severity !== 'pass' && r.severity !== 'warn') || r.requires_human)
+      .map(r => `  - [${r.severity}] ${r.rule}: ${r.message}`)
       .join('\n')
     const detailParts = [
       `Registry returned HTTP ${response.status}${response.statusText ? ' ' + response.statusText : ''}`,


### PR DESCRIPTION
## Why

The HTTP registry publish dispatcher was reading `body.report.rules[].id` but the server's `runner.go` `Report` struct serializes as `verdicts[].rule` (see `digital-human-protocol/server/internal/rules/runner.go` JSON tags). Every 422 publish failure produced an empty `ruleSummary` and the UI showed `verdict=fail` with no actionable reason.

Paired with openkursar/digital-human-protocol#5 — together they unblock the skill publish path end-to-end and make non-pass verdicts visible to the user.

## What

`src/main/store/publish/dispatchers/http-registry.ts`:

1. **Field rename** — response body type now uses `verdicts` (array of `{rule, severity, message, requires_human}`), matching server JSON tags.
2. **Widened verdict surfacing** — the filter for `ruleSummary` now keeps anything that isn't a clean `pass`/`warn`, plus any `warn` with `requires_human: true`. Previously only `fail`/`error` were surfaced, so warns that tripped the auto-merge human-review threshold were silently dropped.

## Verified

Tested locally against the v2 registry server: skill upload now shows verdict + per-rule reasons in the publish UI for both pass and 422 paths.

## Scope

- 1 file changed, 12 insertions, 4 deletions
- No new dependencies, no API surface change on the client side