### PR TITLE
feat: add LiteLLM as built-in AI gateway provider

### DIFF
--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -433,6 +433,20 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     notes: 'Grok-4.1 Fast has 2M context window for agentic tasks'
   },
 
+  {
+    id: 'litellm',
+    name: 'LiteLLM',
+    authType: 'api-key',
+    apiUrl: 'http://localhost:4000',
+    modelsUrl: 'http://localhost:4000/v1/models',
+    models: [],
+    description: 'AI gateway proxy for 100+ LLM providers',
+    website: 'https://github.com/BerriAI/litellm',
+    region: 'global',
+    icon: 'network',
+    notes: 'Models are auto-discovered from the proxy. Set your proxy URL and optional API key'
+  },
+
   // ============================================================================
   // OAuth Providers
   // ============================================================================

--- a/src/shared/types/ai-sources.ts
+++ b/src/shared/types/ai-sources.ts
@@ -79,6 +79,7 @@ export type BuiltinProviderId =
   | 'together'
   | 'fireworks'
   | 'xai'
+  | 'litellm'
   | 'github-copilot'
   | 'claude'
 


### PR DESCRIPTION


## Related Issue

N/A - new feature addition

## Changes

Add [LiteLLM](https://github.com/BerriAI/litellm) as a built-in AI gateway provider, giving users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Vertex AI, Bedrock, OpenRouter, Groq, etc.) through a single OpenAI-compatible proxy.

- `src/shared/types/ai-sources.ts` - Add `'litellm'` to `BuiltinProviderId` union type
- `src/shared/constants/providers.ts` - Add LiteLLM entry to `BUILTIN_PROVIDERS` array with `modelsUrl` for auto-discovery

Models list is empty (`models: []`) because LiteLLM auto-discovers available models via the `modelsUrl` endpoint. 2 files, 15 additions, purely additive.

E2E against a live LiteLLM proxy (Azure AI Foundry Anthropic backend):
```
/v1/models:        ['claude-sonnet-4-6']
Chat completion:   Response: OK | Model: claude-sonnet-4-6 | PASS
```

## Testing

- [x] Ran `npm run dev`
- [x] Tested locally with `test:unit` (172 failures are pre-existing on upstream/main, identical with and without this change)
- [x] Ran `npm run i18n` (no new i18n keys - provider names are data constants)
- [ ] Ran `test:e2e:smoke` (Optional, recommended for large changes)

## Screenshots (if applicable)

NA
