### PR TITLE
Add Requesty as a built-in provider

### DIFF
--- a/src/main/openai-compat-router/server/provider-adapters.ts
+++ b/src/main/openai-compat-router/server/provider-adapters.ts
@@ -109,6 +109,36 @@ const openRouterAdapter: ProviderAdapter = {
 }
 
 // ============================================================================
+// Requesty Adapter
+// ============================================================================
+
+/**
+ * Requesty recommends app attribution headers
+ *
+ * Requesty is OpenAI-compatible and, like OpenRouter, supports optional
+ * app attribution headers:
+ * - App appears in Requesty analytics / leaderboard
+ * - Request analytics show app name instead of "Unknown"
+ *
+ * @see https://requesty.ai/
+ */
+const requestyAdapter: ProviderAdapter = {
+  id: 'requesty',
+  name: 'Requesty',
+
+  match(url: string): boolean {
+    return url.includes('router.requesty.ai')
+  },
+
+  getExtraHeaders(): Record<string, string> {
+    return {
+      'HTTP-Referer': 'https://hello-halo.cc/',
+      'X-Title': 'Halo'
+    }
+  }
+}
+
+// ============================================================================
 // DeepSeek Adapter
 // ============================================================================
 
@@ -230,6 +260,7 @@ const tencentAdapter: ProviderAdapter = {
 const adapters: readonly ProviderAdapter[] = [
   groqAdapter,
   openRouterAdapter,
+  requestyAdapter,
   deepSeekAdapter,
   moonshotAdapter,
   zhipuAdapter,

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -347,7 +347,6 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     description: 'Requesty router with 400+ models across providers',
     website: 'https://requesty.ai/',
     region: 'global',
-    recommended: true,
     icon: 'route',
     notes: 'OpenAI-compatible. Supports optional HTTP-Referer and X-Title headers'
   },

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -332,6 +332,26 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     notes: 'Requires HTTP-Referer and X-Title headers. Supports model array for failover'
   },
   {
+    id: 'requesty',
+    name: 'Requesty',
+    authType: 'api-key',
+    apiUrl: 'https://router.requesty.ai/v1',
+    modelsUrl: 'https://router.requesty.ai/v1/models',
+    models: [
+      { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini' },
+      { id: 'openai/gpt-4o', name: 'GPT-4o' },
+      { id: 'anthropic/claude-sonnet-4-5', name: 'Claude Sonnet 4.5' },
+      { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash' },
+      { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat' }
+    ],
+    description: 'Requesty router with 400+ models across providers',
+    website: 'https://requesty.ai/',
+    region: 'global',
+    recommended: true,
+    icon: 'route',
+    notes: 'OpenAI-compatible. Supports optional HTTP-Referer and X-Title headers'
+  },
+  {
     id: 'groq',
     name: 'Groq',
     authType: 'api-key',

--- a/src/shared/types/ai-sources.ts
+++ b/src/shared/types/ai-sources.ts
@@ -73,6 +73,7 @@ export type BuiltinProviderId =
   | 'yi'
   | 'stepfun'
   | 'openrouter'
+  | 'requesty'
   | 'groq'
   | 'mistral'
   | 'deepinfra'


### PR DESCRIPTION
Adds Requesty as a built-in provider, mirroring the existing OpenRouter entry as closely as possible.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `GET /v1/models` for dynamic model discovery, `provider/model` naming, and optional `HTTP-Referer` / `X-Title` attribution headers, same as OpenRouter. It fits alongside the OpenRouter and LiteLLM entries Halo already ships.

Changes:
- `src/shared/constants/providers.ts`: new `requesty` entry in `BUILTIN_PROVIDERS` (apiUrl `https://router.requesty.ai/v1`, modelsUrl `.../v1/models`, a small seed model list, `icon: 'route'`), placed next to OpenRouter in the global section.
- `src/shared/types/ai-sources.ts`: `'requesty'` added to the `BuiltinProviderId` union.
- `src/main/openai-compat-router/server/provider-adapters.ts`: a `requestyAdapter` mirroring `openRouterAdapter` (matches on `router.requesty.ai`, injects the same optional `HTTP-Referer` / `X-Title` headers), registered in the adapters list.

Seed model ids used are verified live on Requesty (`openai/gpt-4o-mini`, `openai/gpt-4o`, `anthropic/claude-sonnet-4-5`, `google/gemini-2.5-flash`, `deepseek/deepseek-chat`); the full list is fetched dynamically from `/v1/models`.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.