### PR TITLE
fix: hide Windows console windows during process guardian exec (#208) 

### DIFF
--- a/src/main/services/health/process-guardian/platform/win32.ts
+++ b/src/main/services/health/process-guardian/platform/win32.ts
@@ -26,7 +26,7 @@ export class Win32ProcessOps implements PlatformProcessOps {
       // Get-WmiObject provides access to full command line
       const psCommand = `powershell -NoProfile -Command "Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -like '*${pattern}*' } | Select-Object ProcessId, Name, CommandLine | ConvertTo-Json -Compress"`
 
-      const { stdout } = await execAsync(psCommand, { timeout: 10000 })
+      const { stdout } = await execAsync(psCommand, { timeout: 10000, windowsHide: true })
 
       if (!stdout.trim()) {
         return []
@@ -68,7 +68,7 @@ export class Win32ProcessOps implements PlatformProcessOps {
       // /F forces termination (equivalent to SIGKILL)
       // /T terminates child processes
       const forceFlag = signal === 'SIGKILL' ? '/F ' : ''
-      await execAsync(`taskkill ${forceFlag}/PID ${pid} /T`, { timeout: 5000 })
+      await execAsync(`taskkill ${forceFlag}/PID ${pid} /T`, { timeout: 5000, windowsHide: true })
       console.log(`[Health][Win32] Killed process ${pid}`)
     } catch {
       // Goal-based validation: verify the process is gone regardless of error message
@@ -107,7 +107,7 @@ export class Win32ProcessOps implements PlatformProcessOps {
       // Use PowerShell to find processes with matching ParentProcessId
       const psCommand = `powershell -NoProfile -Command "Get-WmiObject Win32_Process | Where-Object { $_.ParentProcessId -eq ${ppid} } | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress"`
 
-      const { stdout } = await execAsync(psCommand, { timeout: 10000 })
+      const { stdout } = await execAsync(psCommand, { timeout: 10000, windowsHide: true })
 
       if (!stdout.trim()) {
         return []


### PR DESCRIPTION
##Summary                                                                                                                                                         
  - Fix #208: Windows 下进程守护 exec 缺少 `windowsHide: true`，启动数字人时 cmd 黑窗一闪而过。                                                                      
  - 在 `src/main/services/health/process-guardian/platform/win32.ts` 的 3 处 `execAsync` 调用（`findByArgs` / `killProcess` / `findChildProcesses`）添加             
  `windowsHide: true`。                                                                                                                                              
  - 与既有约定一致（`git-bash-installer.service.ts:103`、`agent/codex/transport/connection.ts:206` 已使用）。                                                        
  - 新增 `docs/bug-208-verification.md` 验证文档。                                                                                                                   
                                                                                                                                                                     
  ## Root cause                                                                                                                                                      
  Windows 上 `child_process.exec` 默认会启动子进程控制台窗口。进程守护在启动/清理过程中（孤儿扫描、`--halo-managed`                                                  
  扫描、taskkill）调用这些命令——包括启动数字人时——导致 cmd/powershell 窗口闪现。                                                                                     
   
  ## Test plan                                                                                                                                                       
  - [ ] Windows 上冷启动 Halo，无 cmd/powershell 黑窗闪现   
  - [ ] 启动数字人 App，无黑窗闪现，v2-session 正常注册                                                                                                              
  - [ ] 非干净退出后重启，taskkill 清理孤儿无黑窗                                                                                                                    
  - [ ] macOS/Linux 回归无变化                                                                                                                                       
                                                                                                                                                                     
  详细验证步骤见 `docs/bug-208-verification.md`。                                                                                                                    
                                                                                                                                                                     
  Fixes #208                   