### PR TITLE
fix: stop dropping post-finish usage frame in openai-chat stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo",
-  "version": "2.1.10-rc.29",
+  "version": "2.1.10-rc.31",
   "description": "AI that gets things done",
   "type": "module",
   "main": "./out/main/index.mjs",

--- a/src/main/openai-compat-router/__tests__/openai-chat-stream.test.ts
+++ b/src/main/openai-compat-router/__tests__/openai-chat-stream.test.ts
@@ -150,6 +150,27 @@ describe('OpenAIChatStreamHandler empty-response repair', () => {
     expect(textDeltas[0].data.delta.text).toBe('hello')
   })
 
+  it('captures usage frame that arrives after finish_reason (LiteLLM shape)', async () => {
+    // LiteLLM/DeepSeek-flavored upstream emits usage in a chunk AFTER the
+    // finish_reason chunk. The client must not short-circuit on finish_reason
+    // or the terminal usage frame is dropped and message_delta reports zeros.
+    const { res, chunks } = createMockRes()
+    const stream = chatSSE([
+      { id: 'c1', model: 'deepseek-v4-flash', choices: [{ index: 0, delta: { role: 'assistant', content: 'hi' }, finish_reason: null }] },
+      { id: 'c1', model: 'deepseek-v4-flash', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+      { id: 'c1', model: 'deepseek-v4-flash', choices: [{ index: 0, delta: {}, finish_reason: null }] },
+      { id: 'c1', model: 'deepseek-v4-flash', choices: [{ index: 0, delta: {}, finish_reason: null }], usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 } }
+    ])
+
+    await streamOpenAIChatToAnthropic(stream, res, 'deepseek-v4-flash')
+
+    const events = parseSSEEvents(chunks)
+    const msgDelta = events.find(e => e.event === 'message_delta')
+    expect(msgDelta?.data.usage.input_tokens).toBe(5)
+    expect(msgDelta?.data.usage.output_tokens).toBe(10)
+    expect(msgDelta?.data.delta.stop_reason).toBe('end_turn')
+  })
+
   it('does not inject placeholder when the response is tool calls', async () => {
     const { res, chunks } = createMockRes()
     const stream = chatSSE([

--- a/src/main/openai-compat-router/stream/openai-chat-stream.ts
+++ b/src/main/openai-compat-router/stream/openai-chat-stream.ts
@@ -139,11 +139,13 @@ export class OpenAIChatStreamHandler extends BaseStreamHandler {
       this.processToolCalls(delta.tool_calls)
     }
 
-    // Process finish reason
+    // Record stop reason but do not terminate the loop here: providers such as
+    // LiteLLM emit the terminal usage frame in a separate chunk AFTER the
+    // finish_reason chunk. Stream termination is driven by SSE `[DONE]` or
+    // upstream EOF instead.
     if (choice.finish_reason) {
       const stopReason = OPENAI_CHAT_STOP_REASON_MAP[choice.finish_reason] || 'end_turn'
       this.setStopReason(stopReason)
-      this.markFinished()
     }
   }
 


### PR DESCRIPTION
## Summary

`openai-chat-stream.ts` called `markFinished()` as soon as a `choice.finish_reason` chunk arrived, which broke the outer SSE read loop before any chunk that followed. Downstream this crashed Claude Code with `Cannot read properties of undefined (reading 'input_tokens')` inside the cli.js auto-mode classifier — but **only on tool_call responses through the halo-cloud direct-upstream path**.

## Why only halo-cloud users saw it

The OpenAI-compat streaming spec allows two placements for the terminal usage frame, and upstreams diverge:

| Placement | Upstreams | Effect on the buggy loop |
|---|---|---|
| inline (usage on same chunk as `finish_reason`) | DeepSeek, Zhipu GLM, DashScope Qwen, Moonshot Kimi | `markFinished()` fires **after** usage is already captured → bug invisible |
| separate frame after `finish_reason` | OpenAI (`include_usage=true`), LiteLLM, vLLM | `markFinished()` fires **before** the usage frame arrives → usage silently dropped |

Before the paired server-side fix in `halo-cloud-gateway/DirectUpstreamStreamClient`, the gateway did **not** inject `stream_options.include_usage=true`, so LiteLLM emitted no usage frame at all. The client-side fallback estimator masked this for text responses (positive estimate), but on tool_call responses the accumulated visible text is near-empty, the estimate collapses toward zero, and the resulting `message_delta` ships without a well-formed usage object — which is what the classifier NPEs on.

Once the gateway started injecting `include_usage=true`, LiteLLM began emitting usage in a post-finish frame, and this client-side bug became the sole remaining blocker.

## Fix

On `finish_reason`, record the stop reason but leave the read loop alone. The stream now terminates on SSE `[DONE]` or upstream EOF, which is the documented behavior for every mainstream OpenAI-compat upstream verified: OpenAI, DeepSeek, Zhipu GLM, DashScope, Moonshot, LiteLLM, vLLM all emit `data: [DONE]`. Anthropic native Messages traffic is unaffected — it goes through `anthropic-stream.ts` and terminates on `message_stop`.

## Test plan

- [x] New regression test `captures usage frame that arrives after finish_reason (LiteLLM shape)` feeds `content -> finish_reason -> empty -> usage -> [DONE]` and asserts final `message_delta` reports `input_tokens=5, output_tokens=10`
- [x] Full `openai-compat-router` test suite passes (189/189)
- [x] Built rc.31 WeBank installer manually and confirmed the tool_call NPE no longer reproduces against halo-cloud direct upstream

## Notes

- `package.json` rc bump (rc.29 -> rc.31) is the build script auto-bump that produced the shipped WeBank installer; folded into this commit for traceability.
- Same `isFinished`-break pattern still lives in `anthropic-stream.ts` and `openai-responses-stream.ts` — not touched here since neither has a known reproduction, but recommended as a follow-up audit.