### PR TITLE
fix: forward max_tokens correctly through OpenAI-compat converters (#137)

### DIFF
--- a/src/main/openai-compat-router/__tests__/converters.test.ts
+++ b/src/main/openai-compat-router/__tests__/converters.test.ts
@@ -50,37 +50,6 @@ describe('Request Converters', () => {
       expect(result.request.max_tokens).toBeUndefined()
     })
 
-    it('should route max_tokens to max_completion_tokens for reasoning models', () => {
-      // OpenAI reasoning family rejects `max_tokens` with HTTP 400; the
-      // converter must emit `max_completion_tokens` instead so the user's
-      // Halo "max output tokens" setting is honored without breaking the
-      // request.
-      const request: AnthropicRequest = {
-        model: 'o3-mini',
-        max_tokens: 32000,
-        messages: [{ role: 'user', content: 'Hello' }]
-      }
-
-      const result = convertAnthropicToOpenAIChat(request)
-
-      expect(result.request.max_completion_tokens).toBe(32000)
-      expect(result.request.max_tokens).toBeUndefined()
-    })
-
-    it('should keep max_tokens for gpt-4o-1 (non-reasoning, starts with "o" trap)', () => {
-      // Guard against a naive startsWith('o') check trapping "gpt-4o-1".
-      const request: AnthropicRequest = {
-        model: 'gpt-4o-1',
-        max_tokens: 4096,
-        messages: [{ role: 'user', content: 'Hello' }]
-      }
-
-      const result = convertAnthropicToOpenAIChat(request)
-
-      expect(result.request.max_tokens).toBe(4096)
-      expect(result.request.max_completion_tokens).toBeUndefined()
-    })
-
     it('should convert system prompt to system message', () => {
       const request: AnthropicRequest = {
         model: 'claude-3-opus',
@@ -484,21 +453,6 @@ describe('Request Converters', () => {
       expect(functionCall).toBeDefined()
       expect(functionCall.call_id).toBe('call_789')
       expect(functionCall.name).toBe('search')
-    })
-
-    it('should omit max_output_tokens when max_tokens is not a positive value', () => {
-      // Mirrors the Chat Completions boundary guard: non-positive values must
-      // not be forwarded so providers fall back to their own defaults rather
-      // than receiving an invalid zero/negative cap.
-      const request: AnthropicRequest = {
-        model: 'claude-3-opus',
-        max_tokens: 0,
-        messages: [{ role: 'user', content: 'Hello!' }]
-      }
-
-      const result = convertAnthropicToOpenAIResponses(request)
-
-      expect(result.request.max_output_tokens).toBeUndefined()
     })
   })
 

--- a/src/main/openai-compat-router/__tests__/converters.test.ts
+++ b/src/main/openai-compat-router/__tests__/converters.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit Tests for Converters (colocated)
  *
- * This file is outside the vitest CI include glob (`tests/unit/**/*.test.ts`)
- * and runs only when invoked manually. It is retained for local development
- * of legacy converter behavior.
+ * This file is outside the vitest CI include pattern and runs only when
+ * invoked manually. It is retained for local development of legacy converter
+ * behavior.
  *
  * Canonical tests for issue #137 (max_tokens routing, reasoning model
  * detection, output-token normalization) live in

--- a/src/main/openai-compat-router/__tests__/converters.test.ts
+++ b/src/main/openai-compat-router/__tests__/converters.test.ts
@@ -1,5 +1,14 @@
 /**
- * Unit Tests for Converters
+ * Unit Tests for Converters (colocated)
+ *
+ * This file is outside the vitest CI include glob (`tests/unit/**/*.test.ts`)
+ * and runs only when invoked manually. It is retained for local development
+ * of legacy converter behavior.
+ *
+ * Canonical tests for issue #137 (max_tokens routing, reasoning model
+ * detection, output-token normalization) live in
+ * `tests/unit/services/openai-compat-converters.test.ts` — that file is the
+ * mandatory pre-handoff validation source. Do not add new #137 coverage here.
  */
 
 import { describe, it, expect } from 'vitest'

--- a/src/main/openai-compat-router/__tests__/converters.test.ts
+++ b/src/main/openai-compat-router/__tests__/converters.test.ts
@@ -50,6 +50,37 @@ describe('Request Converters', () => {
       expect(result.request.max_tokens).toBeUndefined()
     })
 
+    it('should route max_tokens to max_completion_tokens for reasoning models', () => {
+      // OpenAI reasoning family rejects `max_tokens` with HTTP 400; the
+      // converter must emit `max_completion_tokens` instead so the user's
+      // Halo "max output tokens" setting is honored without breaking the
+      // request.
+      const request: AnthropicRequest = {
+        model: 'o3-mini',
+        max_tokens: 32000,
+        messages: [{ role: 'user', content: 'Hello' }]
+      }
+
+      const result = convertAnthropicToOpenAIChat(request)
+
+      expect(result.request.max_completion_tokens).toBe(32000)
+      expect(result.request.max_tokens).toBeUndefined()
+    })
+
+    it('should keep max_tokens for gpt-4o-1 (non-reasoning, starts with "o" trap)', () => {
+      // Guard against a naive startsWith('o') check trapping "gpt-4o-1".
+      const request: AnthropicRequest = {
+        model: 'gpt-4o-1',
+        max_tokens: 4096,
+        messages: [{ role: 'user', content: 'Hello' }]
+      }
+
+      const result = convertAnthropicToOpenAIChat(request)
+
+      expect(result.request.max_tokens).toBe(4096)
+      expect(result.request.max_completion_tokens).toBeUndefined()
+    })
+
     it('should convert system prompt to system message', () => {
       const request: AnthropicRequest = {
         model: 'claude-3-opus',
@@ -415,8 +446,9 @@ describe('Request Converters', () => {
       const result = convertAnthropicToOpenAIResponses(request)
 
       expect(result.request.model).toBe('claude-3-opus')
-      // max_output_tokens is deliberately omitted — many providers don't support it
-      expect(result.request.max_output_tokens).toBeUndefined()
+      // The Responses API field `max_output_tokens` is part of the public spec
+      // and is forwarded so the user's "max output tokens" setting is honored.
+      expect(result.request.max_output_tokens).toBe(1024)
       expect(result.request.input).toHaveLength(1)
       expect((result.request.input as any)[0].role).toBe('user')
       expect((result.request.input as any)[0].content[0]).toEqual({
@@ -452,6 +484,21 @@ describe('Request Converters', () => {
       expect(functionCall).toBeDefined()
       expect(functionCall.call_id).toBe('call_789')
       expect(functionCall.name).toBe('search')
+    })
+
+    it('should omit max_output_tokens when max_tokens is not a positive value', () => {
+      // Mirrors the Chat Completions boundary guard: non-positive values must
+      // not be forwarded so providers fall back to their own defaults rather
+      // than receiving an invalid zero/negative cap.
+      const request: AnthropicRequest = {
+        model: 'claude-3-opus',
+        max_tokens: 0,
+        messages: [{ role: 'user', content: 'Hello!' }]
+      }
+
+      const result = convertAnthropicToOpenAIResponses(request)
+
+      expect(result.request.max_output_tokens).toBeUndefined()
     })
   })
 

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
@@ -9,7 +9,7 @@ import {
   convertAnthropicToolChoiceToOpenAIChat,
   convertAnthropicThinkingToChatReasoningEffort
 } from '../tools'
-import { supportsVisionById } from '../../../../shared/constants/model-capabilities'
+import { supportsVisionById, isReasoningModelById } from '../../../../shared/constants/model-capabilities'
 
 export interface ConversionResult {
   request: OpenAIChatRequest
@@ -49,8 +49,16 @@ export function convertAnthropicToOpenAIChat(anthropicRequest: AnthropicRequest)
   // so honoring it lets downstream OpenAI-compatible providers respect the
   // user's Halo "max output tokens" setting instead of falling back to a
   // provider default that may truncate long responses.
+  //
+  // OpenAI reasoning models (o1/o3/o4-mini, gpt-5 thinking variants) reject
+  // `max_tokens` with HTTP 400 and only accept `max_completion_tokens`. Route
+  // the value to the correct field based on the model family.
   if (typeof anthropicRequest.max_tokens === 'number' && anthropicRequest.max_tokens > 0) {
-    openaiRequest.max_tokens = anthropicRequest.max_tokens
+    if (isReasoningModelById(anthropicRequest.model)) {
+      openaiRequest.max_completion_tokens = anthropicRequest.max_tokens
+    } else {
+      openaiRequest.max_tokens = anthropicRequest.max_tokens
+    }
   }
 
   // Add tools if present

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
@@ -46,11 +46,6 @@ export function convertAnthropicToOpenAIChat(anthropicRequest: AnthropicRequest)
     stream: anthropicRequest.stream
   }
 
-  // Forward the user-configured output length. Anthropic requires max_tokens,
-  // so honoring it lets downstream OpenAI-compatible providers respect the
-  // user's Halo "max output tokens" setting instead of falling back to a
-  // provider default that may truncate long responses.
-  //
   // OpenAI reasoning models (o1/o3/o4-mini, gpt-5 thinking variants) reject
   // `max_tokens` with HTTP 400 and only accept `max_completion_tokens`. Route
   // the value to the correct field based on the model family.

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
@@ -10,6 +10,7 @@ import {
   convertAnthropicThinkingToChatReasoningEffort
 } from '../tools'
 import { supportsVisionById, isReasoningModelById } from '../../../../shared/constants/model-capabilities'
+import { resolveOutputTokenLimit } from './max-tokens'
 
 export interface ConversionResult {
   request: OpenAIChatRequest
@@ -53,11 +54,12 @@ export function convertAnthropicToOpenAIChat(anthropicRequest: AnthropicRequest)
   // OpenAI reasoning models (o1/o3/o4-mini, gpt-5 thinking variants) reject
   // `max_tokens` with HTTP 400 and only accept `max_completion_tokens`. Route
   // the value to the correct field based on the model family.
-  if (typeof anthropicRequest.max_tokens === 'number' && anthropicRequest.max_tokens > 0) {
+  const outputTokens = resolveOutputTokenLimit(anthropicRequest.max_tokens)
+  if (outputTokens !== undefined) {
     if (isReasoningModelById(anthropicRequest.model)) {
-      openaiRequest.max_completion_tokens = anthropicRequest.max_tokens
+      openaiRequest.max_completion_tokens = outputTokens
     } else {
-      openaiRequest.max_tokens = anthropicRequest.max_tokens
+      openaiRequest.max_tokens = outputTokens
     }
   }
 

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -61,11 +61,9 @@ export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicReq
     stream: anthropicRequest.stream
   }
 
-  // Forward the user-configured output length, mirroring the Chat Completions
-  // path. The Responses API field is `max_output_tokens` and is part of the
-  // public spec, so providers implementing the Responses endpoint accept it.
-  // Without this, Halo's "max output tokens" setting is silently dropped for
-  // any backend routed through the Responses API.
+  // Mirror the Chat Completions path. `max_output_tokens` is part of the
+  // Responses API public spec — without forwarding, Halo's "max output tokens"
+  // setting is silently dropped for Responses-routed backends.
   const outputTokens = resolveOutputTokenLimit(anthropicRequest.max_tokens)
   if (outputTokens !== undefined) {
     request.max_output_tokens = outputTokens

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -10,6 +10,7 @@ import {
   convertAnthropicThinkingToResponsesReasoning
 } from '../tools'
 import { supportsVisionById } from '../../../../shared/constants/model-capabilities'
+import { resolveOutputTokenLimit } from './max-tokens'
 
 export interface ConversionResult {
   request: OpenAIResponsesRequest
@@ -65,8 +66,9 @@ export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicReq
   // public spec, so providers implementing the Responses endpoint accept it.
   // Without this, Halo's "max output tokens" setting is silently dropped for
   // any backend routed through the Responses API.
-  if (typeof anthropicRequest.max_tokens === 'number' && anthropicRequest.max_tokens > 0) {
-    request.max_output_tokens = anthropicRequest.max_tokens
+  const outputTokens = resolveOutputTokenLimit(anthropicRequest.max_tokens)
+  if (outputTokens !== undefined) {
+    request.max_output_tokens = outputTokens
   }
 
   // Add tools if present

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -54,11 +54,19 @@ export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicReq
   const hasTools = !!tools && tools.length > 0
 
   // Build request - only include essential parameters
-  // Omit max_output_tokens as many providers don't support it
   const request: OpenAIResponsesRequest = {
     model: anthropicRequest.model,
     input: inputItems,
     stream: anthropicRequest.stream
+  }
+
+  // Forward the user-configured output length, mirroring the Chat Completions
+  // path. The Responses API field is `max_output_tokens` and is part of the
+  // public spec, so providers implementing the Responses endpoint accept it.
+  // Without this, Halo's "max output tokens" setting is silently dropped for
+  // any backend routed through the Responses API.
+  if (typeof anthropicRequest.max_tokens === 'number' && anthropicRequest.max_tokens > 0) {
+    request.max_output_tokens = anthropicRequest.max_tokens
   }
 
   // Add tools if present

--- a/src/main/openai-compat-router/converters/request/index.ts
+++ b/src/main/openai-compat-router/converters/request/index.ts
@@ -11,3 +11,5 @@ export {
   convertAnthropicToOpenAIResponses,
   convertRequest as convertRequestToResponses
 } from './anthropic-to-openai-responses'
+
+export { resolveOutputTokenLimit } from './max-tokens'

--- a/src/main/openai-compat-router/converters/request/index.ts
+++ b/src/main/openai-compat-router/converters/request/index.ts
@@ -11,5 +11,3 @@ export {
   convertAnthropicToOpenAIResponses,
   convertRequest as convertRequestToResponses
 } from './anthropic-to-openai-responses'
-
-export { resolveOutputTokenLimit } from './max-tokens'

--- a/src/main/openai-compat-router/converters/request/max-tokens.ts
+++ b/src/main/openai-compat-router/converters/request/max-tokens.ts
@@ -1,0 +1,37 @@
+/**
+ * Output-Length Parameter Resolution
+ *
+ * Centralized normalization for the `max_tokens` value that arrives on an
+ * Anthropic-shaped request. Both the Chat Completions and Responses API
+ * converters need the same gating + integer hygiene, so the logic lives here
+ * to avoid drift between the two paths.
+ *
+ * Responsibilities:
+ *   - Drop non-positive values (0, negative) — let the provider use its own
+ *     default rather than emitting an invalid cap.
+ *   - Truncate fractional values to an integer. `AnthropicRequest.max_tokens`
+ *     is typed `number` (not `integer`), and although the Halo UI steppers and
+ *     the Anthropic SDK both constrain to integers, this is the protocol
+ *     boundary where untrusted upstream values are normalized once before
+ *     being fanned out to provider-specific fields.
+ */
+
+/**
+ * Normalize the Anthropic `max_tokens` into a positive integer suitable for
+ * an OpenAI-compatible output-length field, or return `undefined` when the
+ * value should be omitted entirely.
+ *
+ * @param maxTokens - The raw `max_tokens` from the Anthropic request.
+ * @returns A positive integer, or `undefined` to omit the field.
+ */
+export function resolveOutputTokenLimit(maxTokens: number | undefined | null): number | undefined {
+  if (typeof maxTokens !== 'number' || !Number.isFinite(maxTokens)) {
+    return undefined
+  }
+  // Truncate any fractional part — OpenAI-compatible APIs require an integer
+  // and reject (e.g. HTTP 400) non-integer values for max_tokens /
+  // max_completion_tokens / max_output_tokens.
+  const truncated = Math.trunc(maxTokens)
+  // Truncation can collapse values in (0, 1) to 0, which is not a valid cap.
+  return truncated > 0 ? truncated : undefined
+}

--- a/src/main/openai-compat-router/converters/request/max-tokens.ts
+++ b/src/main/openai-compat-router/converters/request/max-tokens.ts
@@ -1,35 +1,18 @@
 /**
- * Output-Length Parameter Resolution
- *
- * Centralized normalization for the `max_tokens` value that arrives on an
- * Anthropic-shaped request. Both the Chat Completions and Responses API
- * converters need the same gating + integer hygiene, so the logic lives here
- * to avoid drift between the two paths.
- *
- * Responsibilities:
- *   - Drop non-positive values (0, negative) — let the provider use its own
- *     default rather than emitting an invalid cap.
- *   - Truncate fractional values to an integer. `AnthropicRequest.max_tokens`
- *     is typed `number` (not `integer`), and this is the protocol boundary
- *     where upstream values are normalized once before being fanned out to
- *     provider-specific fields.
- */
-
-/**
  * Normalize the Anthropic `max_tokens` into a positive integer suitable for
  * an OpenAI-compatible output-length field, or return `undefined` when the
  * value should be omitted entirely.
  *
- * @param maxTokens - The raw `max_tokens` from the Anthropic request.
- * @returns A positive integer, or `undefined` to omit the field.
+ * Shared by both the Chat Completions and Responses API converters so the
+ * same gating + integer hygiene is applied once at the protocol boundary.
+ * `AnthropicRequest.max_tokens` is typed `number` (not `integer`), and
+ * OpenAI-compatible APIs reject non-integer values with HTTP 400.
  */
 export function resolveOutputTokenLimit(maxTokens: number | undefined | null): number | undefined {
   if (typeof maxTokens !== 'number' || !Number.isFinite(maxTokens)) {
     return undefined
   }
-  // Truncate any fractional part — OpenAI-compatible APIs require an integer
-  // and reject (e.g. HTTP 400) non-integer values for max_tokens /
-  // max_completion_tokens / max_output_tokens.
+  // OpenAI-compatible APIs reject non-integer output-length fields.
   const truncated = Math.trunc(maxTokens)
   // Truncation can collapse values in (0, 1) to 0, which is not a valid cap.
   return truncated > 0 ? truncated : undefined

--- a/src/main/openai-compat-router/converters/request/max-tokens.ts
+++ b/src/main/openai-compat-router/converters/request/max-tokens.ts
@@ -10,10 +10,9 @@
  *   - Drop non-positive values (0, negative) — let the provider use its own
  *     default rather than emitting an invalid cap.
  *   - Truncate fractional values to an integer. `AnthropicRequest.max_tokens`
- *     is typed `number` (not `integer`), and although the Halo UI steppers and
- *     the Anthropic SDK both constrain to integers, this is the protocol
- *     boundary where untrusted upstream values are normalized once before
- *     being fanned out to provider-specific fields.
+ *     is typed `number` (not `integer`), and this is the protocol boundary
+ *     where upstream values are normalized once before being fanned out to
+ *     provider-specific fields.
  */
 
 /**

--- a/src/shared/constants/model-capabilities.ts
+++ b/src/shared/constants/model-capabilities.ts
@@ -102,13 +102,14 @@ export function supportsVisionById(modelId: string | undefined | null): boolean 
 }
 
 /**
- * Known reasoning model patterns.
+ * Known reasoning model prefixes.
  *
  * OpenAI's reasoning family (o1, o3, o4-mini, gpt-5 thinking variants)
  * deprecates `max_tokens` and only accepts `max_completion_tokens`. Matching
  * these ids lets the OpenAI-compat router emit the right field and avoid an
- * upstream 400. Matches via modelId.toLowerCase().startsWith(pattern) so the
- * version suffix (e.g. `-2024-12-17`, `-mini`) is covered.
+ * upstream 400. Prefixes are matched with a token-boundary guard (see
+ * {@link isReasoningModelById}) so substrings like "gpt-4o-1" are not trapped
+ * and version suffixes (e.g. `-2024-12-17`, `-mini`) are still covered.
  */
 const REASONING_MODEL_PREFIXES: string[] = [
   // OpenAI reasoning family — rejects max_tokens, accepts max_completion_tokens
@@ -123,8 +124,11 @@ const REASONING_MODEL_PREFIXES: string[] = [
  * Chat Completions endpoints.
  *
  * Used by the openai-compat router where only the request body's `model`
- * string is available. Conservative by design: only well-known reasoning
- * family prefixes match, so non-OpenAI providers are unaffected.
+ * string is available. The prefix list is intentionally limited to
+ * well-known OpenAI reasoning families; the token-boundary guard prevents
+ * false positives such as "gpt-4o-1". A non-OpenAI provider that happens
+ * to ship an id starting with one of these prefixes would still match —
+ * providers with such collisions should override at a higher layer.
  */
 export function isReasoningModelById(modelId: string | undefined | null): boolean {
   if (!modelId) return false

--- a/src/shared/constants/model-capabilities.ts
+++ b/src/shared/constants/model-capabilities.ts
@@ -110,6 +110,11 @@ export function supportsVisionById(modelId: string | undefined | null): boolean 
  * upstream 400. Prefixes are matched with a token-boundary guard (see
  * {@link isReasoningModelById}) so substrings like "gpt-4o-1" are not trapped
  * and version suffixes (e.g. `-2024-12-17`, `-mini`) are still covered.
+ *
+ * A non-OpenAI provider that happens to ship an id starting with one of these
+ * prefixes would also match — the list is intentionally limited to minimize
+ * that risk, and providers with such collisions should override at a higher
+ * layer.
  */
 const REASONING_MODEL_PREFIXES: string[] = [
   // OpenAI reasoning family — rejects max_tokens, accepts max_completion_tokens
@@ -121,22 +126,16 @@ const REASONING_MODEL_PREFIXES: string[] = [
 /**
  * Check whether a model id belongs to a reasoning model that requires
  * `max_completion_tokens` instead of `max_tokens` on OpenAI-compatible
- * Chat Completions endpoints.
- *
- * Used by the openai-compat router where only the request body's `model`
- * string is available. The prefix list is intentionally limited to
- * well-known OpenAI reasoning families; the token-boundary guard prevents
- * false positives such as "gpt-4o-1". A non-OpenAI provider that happens
- * to ship an id starting with one of these prefixes would still match —
- * providers with such collisions should override at a higher layer.
+ * Chat Completions endpoints. Used by the openai-compat router where only
+ * the request body's `model` string is available.
  */
 export function isReasoningModelById(modelId: string | undefined | null): boolean {
   if (!modelId) return false
   const lower = modelId.toLowerCase()
-  // Guard against false positives like "gpt-4o-1" — require the family prefix
-  // to be followed by a non-alphanumeric boundary (end of string, '-', '.').
   return REASONING_MODEL_PREFIXES.some((prefix) => {
     if (!lower.startsWith(prefix)) return false
+    // Token-boundary guard: require end-of-string, '-', or '.' after the
+    // prefix so substrings like "o1" in "gpt-4o-1" are not trapped.
     const next = lower[prefix.length]
     return next === undefined || next === '-' || next === '.'
   })

--- a/src/shared/constants/model-capabilities.ts
+++ b/src/shared/constants/model-capabilities.ts
@@ -1,11 +1,16 @@
 /**
- * Model Capabilities — Vision Support Detection
+ * Model Capabilities — Capability Detection From Model IDs
  *
- * Maintains a blacklist of known non-vision models and provides a unified
- * query function for checking vision support. Used by InputArea to block
- * image input for models that don't support it.
+ * Maintains pattern lists for capability inference from a model id string and
+ * provides unified query functions. Currently covers:
+ *   - Vision support: used by InputArea to block image input for non-vision
+ *     models, and by the OpenAI-compat router to strip image blocks.
+ *   - Reasoning model detection: used by the OpenAI-compat router to pick the
+ *     correct output-length parameter (`max_completion_tokens` for reasoning
+ *     models, `max_tokens` otherwise). OpenAI rejects `max_tokens` on the
+ *     o1/o3/o4-mini and gpt-5-thinking families with HTTP 400.
  *
- * Resolution order:
+ * Resolution order (vision):
  *   1. Explicit ModelOption.supportsVision (provider-declared) — highest priority
  *   2. Vision keyword whitelist (e.g. "-vl", "vision", "omni")
  *   3. Non-vision pattern blacklist (e.g. "deepseek", "glm-4")
@@ -94,4 +99,41 @@ export function supportsVision(model: ModelOption): boolean {
 export function supportsVisionById(modelId: string | undefined | null): boolean {
   if (!modelId) return true
   return inferVisionSupport(modelId)
+}
+
+/**
+ * Known reasoning model patterns.
+ *
+ * OpenAI's reasoning family (o1, o3, o4-mini, gpt-5 thinking variants)
+ * deprecates `max_tokens` and only accepts `max_completion_tokens`. Matching
+ * these ids lets the OpenAI-compat router emit the right field and avoid an
+ * upstream 400. Matches via modelId.toLowerCase().startsWith(pattern) so the
+ * version suffix (e.g. `-2024-12-17`, `-mini`) is covered.
+ */
+const REASONING_MODEL_PREFIXES: string[] = [
+  // OpenAI reasoning family — rejects max_tokens, accepts max_completion_tokens
+  'o1', 'o3', 'o4',
+  // GPT-5 thinking variants — same restriction
+  'gpt-5-thinking', 'gpt-5-reasoning'
+]
+
+/**
+ * Check whether a model id belongs to a reasoning model that requires
+ * `max_completion_tokens` instead of `max_tokens` on OpenAI-compatible
+ * Chat Completions endpoints.
+ *
+ * Used by the openai-compat router where only the request body's `model`
+ * string is available. Conservative by design: only well-known reasoning
+ * family prefixes match, so non-OpenAI providers are unaffected.
+ */
+export function isReasoningModelById(modelId: string | undefined | null): boolean {
+  if (!modelId) return false
+  const lower = modelId.toLowerCase()
+  // Guard against false positives like "gpt-4o-1" — require the family prefix
+  // to be followed by a non-alphanumeric boundary (end of string, '-', '.').
+  return REASONING_MODEL_PREFIXES.some((prefix) => {
+    if (!lower.startsWith(prefix)) return false
+    const next = lower[prefix.length]
+    return next === undefined || next === '-' || next === '.'
+  })
 }

--- a/src/shared/constants/model-capabilities.ts
+++ b/src/shared/constants/model-capabilities.ts
@@ -110,11 +110,6 @@ export function supportsVisionById(modelId: string | undefined | null): boolean 
  * upstream 400. Prefixes are matched with a token-boundary guard (see
  * {@link isReasoningModelById}) so substrings like "gpt-4o-1" are not trapped
  * and version suffixes (e.g. `-2024-12-17`, `-mini`) are still covered.
- *
- * A non-OpenAI provider that happens to ship an id starting with one of these
- * prefixes would also match — the list is intentionally limited to minimize
- * that risk, and providers with such collisions should override at a higher
- * layer.
  */
 const REASONING_MODEL_PREFIXES: string[] = [
   // OpenAI reasoning family — rejects max_tokens, accepts max_completion_tokens

--- a/tests/unit/services/openai-compat-converters.test.ts
+++ b/tests/unit/services/openai-compat-converters.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the OpenAI-compat request converters — max_tokens forwarding.
+ *
+ * Scope (issue #137):
+ *   - Chat Completions path routes `max_tokens` to the correct field depending
+ *     on whether the target model is an OpenAI reasoning model
+ *     (`max_completion_tokens`) or a standard model (`max_tokens`).
+ *   - Responses API path forwards `max_output_tokens` (part of the public spec)
+ *     so the user's Halo "max output tokens" setting is honored for backends
+ *     routed through the Responses endpoint.
+ *   - `isReasoningModelById` correctly classifies the OpenAI reasoning family
+ *     (o1/o3/o4-mini, gpt-5-thinking variants) and avoids the `gpt-4o-1`
+ *     false-positive trap.
+ *
+ * These tests live under the canonical `tests/unit/services/` path so they are
+ * picked up by the project vitest config (include: 'unit/<glob>.test.ts').
+ * The colocated `src/main/openai-compat-router/__tests__/converters.test.ts`
+ * is a legacy file and is kept in sync with the same invariants, but only this
+ * file is part of the mandatory pre-handoff validation run.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  convertAnthropicToOpenAIChat,
+  convertAnthropicToOpenAIResponses
+} from '../../../src/main/openai-compat-router/converters'
+import type { AnthropicRequest } from '../../../src/main/openai-compat-router/types'
+import { isReasoningModelById } from '../../../src/shared/constants/model-capabilities'
+
+describe('Chat Completions — max_tokens forwarding (issue #137)', () => {
+  it('routes max_tokens to max_completion_tokens for OpenAI reasoning models', () => {
+    // The OpenAI reasoning family (o1/o3/o4-mini, gpt-5-thinking) rejects
+    // `max_tokens` with HTTP 400. The converter must emit
+    // `max_completion_tokens` so the user's Halo "max output tokens" setting
+    // is honored without breaking the request.
+    const request: AnthropicRequest = {
+      model: 'o3-mini',
+      max_tokens: 32000,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_completion_tokens).toBe(32000)
+    expect(result.request.max_tokens).toBeUndefined()
+  })
+
+  it('keeps max_tokens for standard (non-reasoning) models', () => {
+    const request: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_tokens).toBe(4096)
+    expect(result.request.max_completion_tokens).toBeUndefined()
+  })
+
+  it('keeps max_tokens for gpt-4o-1 (non-reasoning, starts-with-"o" trap)', () => {
+    // Guards against a naive startsWith('o') check trapping "gpt-4o-1".
+    // The detector requires the family prefix to end on a token boundary.
+    const request: AnthropicRequest = {
+      model: 'gpt-4o-1',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_tokens).toBe(4096)
+    expect(result.request.max_completion_tokens).toBeUndefined()
+  })
+
+  it('routes to max_completion_tokens for gpt-5-thinking variants', () => {
+    const request: AnthropicRequest = {
+      model: 'gpt-5-thinking-2026-01-01',
+      max_tokens: 16000,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_completion_tokens).toBe(16000)
+    expect(result.request.max_tokens).toBeUndefined()
+  })
+
+  it('omits both fields when max_tokens is not a positive value', () => {
+    // Non-positive values must not be forwarded so providers fall back to
+    // their own defaults rather than receiving an invalid zero/negative cap.
+    const request: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 0,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_tokens).toBeUndefined()
+    expect(result.request.max_completion_tokens).toBeUndefined()
+  })
+})
+
+describe('Responses API — max_output_tokens forwarding (issue #137)', () => {
+  it('forwards max_output_tokens so the user setting is honored', () => {
+    // `max_output_tokens` is part of the Responses API public spec. Without
+    // forwarding, Halo's "max output tokens" setting is silently dropped for
+    // any backend routed through the Responses API.
+    const request: AnthropicRequest = {
+      model: 'claude-3-opus',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.max_output_tokens).toBe(1024)
+  })
+
+  it('omits max_output_tokens when max_tokens is not a positive value', () => {
+    const request: AnthropicRequest = {
+      model: 'claude-3-opus',
+      max_tokens: 0,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.max_output_tokens).toBeUndefined()
+  })
+})
+
+describe('isReasoningModelById', () => {
+  it('classifies OpenAI o-family as reasoning', () => {
+    expect(isReasoningModelById('o1')).toBe(true)
+    expect(isReasoningModelById('o1-mini')).toBe(true)
+    expect(isReasoningModelById('o3')).toBe(true)
+    expect(isReasoningModelById('o3-mini')).toBe(true)
+    expect(isReasoningModelById('o4-mini')).toBe(true)
+    expect(isReasoningModelById('o3-2024-12-17')).toBe(true)
+  })
+
+  it('classifies gpt-5-thinking variants as reasoning', () => {
+    expect(isReasoningModelById('gpt-5-thinking')).toBe(true)
+    expect(isReasoningModelById('gpt-5-reasoning')).toBe(true)
+    expect(isReasoningModelById('gpt-5-thinking-2026-01-01')).toBe(true)
+  })
+
+  it('rejects the gpt-4o-1 false-positive trap', () => {
+    // A naive startsWith('o') check would trap "gpt-4o-1". The detector must
+    // require the family prefix to end on a token boundary.
+    expect(isReasoningModelById('gpt-4o-1')).toBe(false)
+    expect(isReasoningModelById('gpt-4o')).toBe(false)
+    expect(isReasoningModelById('gpt-4o-mini')).toBe(false)
+  })
+
+  it('rejects non-OpenAI providers and standard models', () => {
+    expect(isReasoningModelById('claude-sonnet-4-6')).toBe(false)
+    expect(isReasoningModelById('deepseek-chat')).toBe(false)
+    expect(isReasoningModelById('glm-4')).toBe(false)
+  })
+
+  it('handles edge cases safely', () => {
+    expect(isReasoningModelById(undefined)).toBe(false)
+    expect(isReasoningModelById(null)).toBe(false)
+    expect(isReasoningModelById('')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isReasoningModelById('O3-MINI')).toBe(true)
+    expect(isReasoningModelById('GPT-5-Thinking')).toBe(true)
+  })
+})

--- a/tests/unit/services/openai-compat-converters.test.ts
+++ b/tests/unit/services/openai-compat-converters.test.ts
@@ -14,9 +14,6 @@
  *
  * These tests live under the canonical `tests/unit/services/` path so they are
  * picked up by the project vitest config (include: 'unit/<glob>.test.ts').
- * The colocated `src/main/openai-compat-router/__tests__/converters.test.ts`
- * is a legacy file and is kept in sync with the same invariants, but only this
- * file is part of the mandatory pre-handoff validation run.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -60,8 +57,9 @@ describe('Chat Completions — max_tokens forwarding (issue #137)', () => {
   })
 
   it('keeps max_tokens for gpt-4o-1 (non-reasoning, starts-with-"o" trap)', () => {
-    // Guards against a naive startsWith('o') check trapping "gpt-4o-1".
-    // The detector requires the family prefix to end on a token boundary.
+    // "gpt-4o-1" contains the prefix "o1" as a substring but must not be
+    // classified as a reasoning model. The detector's token-boundary guard
+    // (prefix must be followed by end-of-string, '-', or '.') rejects it.
     const request: AnthropicRequest = {
       model: 'gpt-4o-1',
       max_tokens: 4096,
@@ -202,8 +200,9 @@ describe('isReasoningModelById', () => {
   })
 
   it('rejects the gpt-4o-1 false-positive trap', () => {
-    // A naive startsWith('o') check would trap "gpt-4o-1". The detector must
-    // require the family prefix to end on a token boundary.
+    // "gpt-4o-1" contains the "o1" prefix as a substring but is not a reasoning
+    // model. The token-boundary guard (prefix must be followed by end-of-string,
+    // '-', or '.') rejects it.
     expect(isReasoningModelById('gpt-4o-1')).toBe(false)
     expect(isReasoningModelById('gpt-4o')).toBe(false)
     expect(isReasoningModelById('gpt-4o-mini')).toBe(false)

--- a/tests/unit/services/openai-compat-converters.test.ts
+++ b/tests/unit/services/openai-compat-converters.test.ts
@@ -114,6 +114,38 @@ describe('Chat Completions — max_tokens forwarding (issue #137)', () => {
 
     expect(result.request.max_tokens).toBe(4096)
   })
+
+  it('truncates fractional max_tokens to an integer for reasoning models', () => {
+    // Cross-path: the integer normalization in resolveOutputTokenLimit must
+    // run before the reasoning-model routing, so max_completion_tokens also
+    // receives a truncated integer.
+    const request: AnthropicRequest = {
+      model: 'o3-mini',
+      max_tokens: 32000.7,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_completion_tokens).toBe(32000)
+    expect(result.request.max_tokens).toBeUndefined()
+  })
+
+  it('omits both fields when max_tokens is 0 for reasoning models', () => {
+    // Cross-path: the non-positive guard must short-circuit before the
+    // reasoning routing, so neither max_completion_tokens nor max_tokens
+    // is emitted.
+    const request: AnthropicRequest = {
+      model: 'o3-mini',
+      max_tokens: 0,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_completion_tokens).toBeUndefined()
+    expect(result.request.max_tokens).toBeUndefined()
+  })
 })
 
 describe('Responses API — max_output_tokens forwarding (issue #137)', () => {

--- a/tests/unit/services/openai-compat-converters.test.ts
+++ b/tests/unit/services/openai-compat-converters.test.ts
@@ -24,6 +24,7 @@ import {
   convertAnthropicToOpenAIChat,
   convertAnthropicToOpenAIResponses
 } from '../../../src/main/openai-compat-router/converters'
+import { resolveOutputTokenLimit } from '../../../src/main/openai-compat-router/converters/request/max-tokens'
 import type { AnthropicRequest } from '../../../src/main/openai-compat-router/types'
 import { isReasoningModelById } from '../../../src/shared/constants/model-capabilities'
 
@@ -100,6 +101,21 @@ describe('Chat Completions — max_tokens forwarding (issue #137)', () => {
     expect(result.request.max_tokens).toBeUndefined()
     expect(result.request.max_completion_tokens).toBeUndefined()
   })
+
+  it('truncates fractional max_tokens to an integer', () => {
+    // OpenAI-compatible APIs require an integer for max_tokens /
+    // max_completion_tokens; a fractional value triggers HTTP 400. The
+    // converter normalizes at the protocol boundary.
+    const request: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 4096.9,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.max_tokens).toBe(4096)
+  })
 })
 
 describe('Responses API — max_output_tokens forwarding (issue #137)', () => {
@@ -128,6 +144,44 @@ describe('Responses API — max_output_tokens forwarding (issue #137)', () => {
     const result = convertAnthropicToOpenAIResponses(request)
 
     expect(result.request.max_output_tokens).toBeUndefined()
+  })
+
+  it('truncates fractional max_tokens to an integer', () => {
+    const request: AnthropicRequest = {
+      model: 'claude-3-opus',
+      max_tokens: 1024.5,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.max_output_tokens).toBe(1024)
+  })
+})
+
+describe('resolveOutputTokenLimit', () => {
+  it('returns the value as-is when it is already a positive integer', () => {
+    expect(resolveOutputTokenLimit(1)).toBe(1)
+    expect(resolveOutputTokenLimit(8192)).toBe(8192)
+  })
+
+  it('truncates fractional values to the integer part', () => {
+    expect(resolveOutputTokenLimit(1024.9)).toBe(1024)
+    expect(resolveOutputTokenLimit(0.5)).toBeUndefined() // truncates to 0 → not positive
+  })
+
+  it('returns undefined for non-positive values', () => {
+    expect(resolveOutputTokenLimit(0)).toBeUndefined()
+    expect(resolveOutputTokenLimit(-1)).toBeUndefined()
+    expect(resolveOutputTokenLimit(-100)).toBeUndefined()
+  })
+
+  it('returns undefined for nullish / non-finite inputs', () => {
+    expect(resolveOutputTokenLimit(undefined)).toBeUndefined()
+    expect(resolveOutputTokenLimit(null)).toBeUndefined()
+    expect(resolveOutputTokenLimit(NaN)).toBeUndefined()
+    expect(resolveOutputTokenLimit(Infinity)).toBeUndefined()
+    expect(resolveOutputTokenLimit(-Infinity)).toBeUndefined()
   })
 })
 

--- a/tests/unit/services/openai-compat-converters.test.ts
+++ b/tests/unit/services/openai-compat-converters.test.ts
@@ -12,8 +12,8 @@
  *     (o1/o3/o4-mini, gpt-5-thinking variants) and avoids the `gpt-4o-1`
  *     false-positive trap.
  *
- * These tests live under the canonical `tests/unit/services/` path so they are
- * picked up by the project vitest config (include: 'unit/<glob>.test.ts').
+ * These tests live under the canonical `tests/unit/services/` path so they
+ * match the project vitest config's recursive `tests/unit/` include pattern.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -102,8 +102,7 @@ describe('Chat Completions — max_tokens forwarding (issue #137)', () => {
 
   it('truncates fractional max_tokens to an integer', () => {
     // OpenAI-compatible APIs require an integer for max_tokens /
-    // max_completion_tokens; a fractional value triggers HTTP 400. The
-    // converter normalizes at the protocol boundary.
+    // max_completion_tokens; a fractional value triggers HTTP 400.
     const request: AnthropicRequest = {
       model: 'gpt-4o',
       max_tokens: 4096.9,
@@ -232,9 +231,8 @@ describe('isReasoningModelById', () => {
   })
 
   it('rejects the gpt-4o-1 false-positive trap', () => {
-    // "gpt-4o-1" contains the "o1" prefix as a substring but is not a reasoning
-    // model. The token-boundary guard (prefix must be followed by end-of-string,
-    // '-', or '.') rejects it.
+    // Exercises the same token-boundary guard as the converter-level test
+    // above, but at the detector level.
     expect(isReasoningModelById('gpt-4o-1')).toBe(false)
     expect(isReasoningModelById('gpt-4o')).toBe(false)
     expect(isReasoningModelById('gpt-4o-mini')).toBe(false)

--- a/tests/unit/services/openai-compat-converters.test.ts
+++ b/tests/unit/services/openai-compat-converters.test.ts
@@ -212,6 +212,12 @@ describe('resolveOutputTokenLimit', () => {
     expect(resolveOutputTokenLimit(Infinity)).toBeUndefined()
     expect(resolveOutputTokenLimit(-Infinity)).toBeUndefined()
   })
+
+  it('preserves large integers without truncation', () => {
+    // Guards against a future refactor to bitwise truncation (~~value, | 0)
+    // which would silently corrupt values above 2^31.
+    expect(resolveOutputTokenLimit(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER)
+  })
 })
 
 describe('isReasoningModelById', () => {
@@ -253,5 +259,12 @@ describe('isReasoningModelById', () => {
   it('is case-insensitive', () => {
     expect(isReasoningModelById('O3-MINI')).toBe(true)
     expect(isReasoningModelById('GPT-5-Thinking')).toBe(true)
+  })
+
+  it('accepts dot-separated version suffixes', () => {
+    // The boundary guard treats '.' as a valid separator, so a hypothetical
+    // minor-version id like "o3.5" is classified as reasoning.
+    expect(isReasoningModelById('o3.5')).toBe(true)
+    expect(isReasoningModelById('o1.2')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
Fixes #137

- Forward `max_tokens` correctly through OpenAI-compat converters (Chat Completions + Responses API)
- Route output-length field to `max_completion_tokens` for OpenAI reasoning models (o1/o3/o4-mini, gpt-5-thinking variants) to avoid upstream HTTP 400
- Forward `max_output_tokens` on the Responses API public spec path
- Add `resolveOutputTokenLimit` for centralized integer/finite normalization
- Add `isReasoningModelById` with token-boundary guard (avoids `gpt-4o-1` false positive)

## Test plan
- [x] 36 unit tests pass (23 converters + 13 model-capabilities)
- [x] `npm run build` succeeds, no TypeScript errors
- [ ] Manual verification in running app (dev mode)