### PR TITLE
fix: inject stream_options.include_usage for OpenAI-compat streaming (#181)

### DIFF
--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
@@ -46,9 +46,8 @@ export function convertAnthropicToOpenAIChat(anthropicRequest: AnthropicRequest)
     stream: anthropicRequest.stream
   }
 
-  // OpenAI-compatible gateways (litellm, OpenAI public API) omit usage from
-  // streamed chunks unless the request explicitly opts in. Without this flag,
-  // `chunk.usage` is always empty, so the TokenUsageIndicator renders zeros.
+  // Issue #181: opt into chunk.usage so TokenUsageIndicator is not zero.
+  // See `stream-options.ts` for the gateway-compat rationale.
   if (openaiRequest.stream) {
     openaiRequest.stream_options = buildStreamOptionsIncludeUsage()
   }

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
@@ -10,6 +10,7 @@ import {
   convertAnthropicThinkingToChatReasoningEffort
 } from '../tools'
 import { supportsVisionById } from '../../../../shared/constants/model-capabilities'
+import { buildStreamOptionsIncludeUsage } from './stream-options'
 
 export interface ConversionResult {
   request: OpenAIChatRequest
@@ -43,6 +44,13 @@ export function convertAnthropicToOpenAIChat(anthropicRequest: AnthropicRequest)
     model: anthropicRequest.model,
     messages,
     stream: anthropicRequest.stream
+  }
+
+  // OpenAI-compatible gateways (litellm, OpenAI public API) omit usage from
+  // streamed chunks unless the request explicitly opts in. Without this flag,
+  // `chunk.usage` is always empty, so the TokenUsageIndicator renders zeros.
+  if (openaiRequest.stream) {
+    openaiRequest.stream_options = buildStreamOptionsIncludeUsage()
   }
 
   // Forward the user-configured output length. Anthropic requires max_tokens,

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -10,6 +10,7 @@ import {
   convertAnthropicThinkingToResponsesReasoning
 } from '../tools'
 import { supportsVisionById } from '../../../../shared/constants/model-capabilities'
+import { buildStreamOptionsIncludeUsage } from './stream-options'
 
 export interface ConversionResult {
   request: OpenAIResponsesRequest
@@ -59,6 +60,14 @@ export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicReq
     model: anthropicRequest.model,
     input: inputItems,
     stream: anthropicRequest.stream
+  }
+
+  // Mirror the Chat Completions path: OpenAI-compatible gateways return usage
+  // in the final streamed chunk only when `stream_options.include_usage` is
+  // explicitly set. Otherwise the Responses API stream omits usage entirely
+  // and the TokenUsageIndicator shows zeros.
+  if (request.stream) {
+    request.stream_options = buildStreamOptionsIncludeUsage()
   }
 
   // Add tools if present

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -62,13 +62,12 @@ export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicReq
     stream: anthropicRequest.stream
   }
 
-  // Defensive: the OpenAI Responses API returns usage in the `response.completed`
-  // event unconditionally — no `stream_options` gate. However, some OpenAI-compat
-  // gateways (e.g. litellm) internally translate the Responses API to Chat
-  // Completions, where usage IS gated by `stream_options.include_usage`. Without
-  // this flag, such gateways emit no usage in any streamed chunk and the
-  // TokenUsageIndicator shows zeros (issue #181). The field is silently ignored
-  // by the native OpenAI Responses API, so injecting it is harmless there.
+  // Issue #181 (Responses-specific nuance): the native OpenAI Responses API
+  // returns usage in `response.completed` unconditionally and silently ignores
+  // `stream_options`. However, translation-style gateways (e.g. litellm) map
+  // the Responses API to Chat Completions internally, where usage is gated by
+  // `stream_options.include_usage`. Injecting it is harmless for the native
+  // API and required for such gateways.
   if (request.stream) {
     request.stream_options = buildStreamOptionsIncludeUsage()
   }

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -62,10 +62,13 @@ export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicReq
     stream: anthropicRequest.stream
   }
 
-  // Mirror the Chat Completions path: OpenAI-compatible gateways return usage
-  // in the final streamed chunk only when `stream_options.include_usage` is
-  // explicitly set. Otherwise the Responses API stream omits usage entirely
-  // and the TokenUsageIndicator shows zeros.
+  // Defensive: the OpenAI Responses API returns usage in the `response.completed`
+  // event unconditionally — no `stream_options` gate. However, some OpenAI-compat
+  // gateways (e.g. litellm) internally translate the Responses API to Chat
+  // Completions, where usage IS gated by `stream_options.include_usage`. Without
+  // this flag, such gateways emit no usage in any streamed chunk and the
+  // TokenUsageIndicator shows zeros (issue #181). The field is silently ignored
+  // by the native OpenAI Responses API, so injecting it is harmless there.
   if (request.stream) {
     request.stream_options = buildStreamOptionsIncludeUsage()
   }

--- a/src/main/openai-compat-router/converters/request/stream-options.ts
+++ b/src/main/openai-compat-router/converters/request/stream-options.ts
@@ -1,14 +1,16 @@
 /**
- * Shared builder for the OpenAI-compatible `stream_options` object.
+ * Build the OpenAI-compatible `stream_options: { include_usage: true }` object.
  *
- * OpenAI-compatible gateways (including litellm and the OpenAI public API) do
- * not return token usage in streamed chunks unless the request explicitly opts
- * in via `stream_options: { include_usage: true }`. Without this flag, every
- * streamed response has an empty `chunk.usage`, so the downstream accumulator
- * sees zero tokens and the UI's `TokenUsageIndicator` renders all zeros.
+ * Why this exists (issue #181): OpenAI-compat gateways (litellm, OpenAI public
+ * Chat Completions API) only return token usage in the final streamed chunk when
+ * the request explicitly opts in. Without this flag, `chunk.usage` is empty for
+ * every streamed response, so the downstream accumulator sees zero tokens and
+ * the UI's `TokenUsageIndicator` renders all zeros.
  *
- * Both the Chat Completions and Responses API converters delegate to this
- * helper so the contract is applied once at the protocol boundary.
+ * Returned as a function (not a shared constant) so each caller gets a fresh
+ * object and cannot accidentally mutate state shared across requests. Both the
+ * Chat Completions and Responses API converters delegate to this helper so the
+ * contract is applied once at the protocol boundary.
  */
 
 export function buildStreamOptionsIncludeUsage(): { include_usage: true } {

--- a/src/main/openai-compat-router/converters/request/stream-options.ts
+++ b/src/main/openai-compat-router/converters/request/stream-options.ts
@@ -1,16 +1,10 @@
 /**
- * Build the OpenAI-compatible `stream_options: { include_usage: true }` object.
+ * Build `stream_options: { include_usage: true }` for OpenAI-compat streaming.
  *
- * Why this exists (issue #181): OpenAI-compat gateways (litellm, OpenAI public
- * Chat Completions API) only return token usage in the final streamed chunk when
- * the request explicitly opts in. Without this flag, `chunk.usage` is empty for
- * every streamed response, so the downstream accumulator sees zero tokens and
- * the UI's `TokenUsageIndicator` renders all zeros.
- *
- * Returned as a function (not a shared constant) so each caller gets a fresh
- * object and cannot accidentally mutate state shared across requests. Both the
- * Chat Completions and Responses API converters delegate to this helper so the
- * contract is applied once at the protocol boundary.
+ * Without this flag, OpenAI-compat gateways (litellm, OpenAI public Chat
+ * Completions API) omit usage from streamed chunks and `TokenUsageIndicator`
+ * renders zeros — see issue #181. Shared by both converters so the contract
+ * is applied once at the protocol boundary.
  */
 
 export function buildStreamOptionsIncludeUsage(): { include_usage: true } {

--- a/src/main/openai-compat-router/converters/request/stream-options.ts
+++ b/src/main/openai-compat-router/converters/request/stream-options.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared builder for the OpenAI-compatible `stream_options` object.
+ *
+ * OpenAI-compatible gateways (including litellm and the OpenAI public API) do
+ * not return token usage in streamed chunks unless the request explicitly opts
+ * in via `stream_options: { include_usage: true }`. Without this flag, every
+ * streamed response has an empty `chunk.usage`, so the downstream accumulator
+ * sees zero tokens and the UI's `TokenUsageIndicator` renders all zeros.
+ *
+ * Both the Chat Completions and Responses API converters delegate to this
+ * helper so the contract is applied once at the protocol boundary.
+ */
+
+export function buildStreamOptionsIncludeUsage(): { include_usage: true } {
+  return { include_usage: true }
+}

--- a/tests/unit/services/openai-compat-stream-options.test.ts
+++ b/tests/unit/services/openai-compat-stream-options.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the OpenAI-compat request converters — stream_options injection.
+ *
+ * Scope (issue #181):
+ *   - Chat Completions path injects `stream_options: { include_usage: true }`
+ *     when the request has `stream: true`, and omits it otherwise.
+ *   - Responses API path mirrors the Chat Completions behavior.
+ *
+ * OpenAI-compatible gateways (litellm, OpenAI public API) only return usage in
+ * the final streamed chunk when `stream_options.include_usage` is set; without
+ * it, `chunk.usage` is always empty and the UI's TokenUsageIndicator shows
+ * zeros. These tests pin the contract at the protocol boundary.
+ *
+ * These tests live under the canonical `tests/unit/services/` path so they
+ * match the project vitest config's recursive `tests/unit/` include pattern.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  convertAnthropicToOpenAIChat,
+  convertAnthropicToOpenAIResponses
+} from '../../../src/main/openai-compat-router/converters'
+import type { AnthropicRequest } from '../../../src/main/openai-compat-router/types'
+
+describe('Chat Completions — stream_options.include_usage (issue #181)', () => {
+  it('injects stream_options.include_usage when stream is true', () => {
+    // The OpenAI-compat gateway omits usage from streamed chunks unless the
+    // request opts in. The converter must set stream_options.include_usage
+    // so chunk.usage is populated downstream and the TokenUsageIndicator
+    // renders real values instead of zeros.
+    const request: AnthropicRequest = {
+      model: 'gpt-4o',
+      stream: true,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.stream).toBe(true)
+    expect(result.request.stream_options).toEqual({ include_usage: true })
+  })
+
+  it('omits stream_options when stream is false', () => {
+    // Non-streaming responses carry usage in the top-level `usage` field, so
+    // stream_options is unnecessary and must not be injected.
+    const request: AnthropicRequest = {
+      model: 'gpt-4o',
+      stream: false,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.stream).toBe(false)
+    expect(result.request.stream_options).toBeUndefined()
+  })
+
+  it('omits stream_options when stream is not set (default falsy)', () => {
+    // Anthropic's Request type marks `stream` as optional. When the caller
+    // does not opt into streaming, the converter must not add stream_options.
+    const request: AnthropicRequest = {
+      model: 'gpt-4o',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.stream).toBeFalsy()
+    expect(result.request.stream_options).toBeUndefined()
+  })
+
+  it('injects stream_options.include_usage alongside reasoning model routing', () => {
+    // Sanity check: streaming and reasoning-model detection are orthogonal.
+    // A streaming reasoning model request must carry both
+    // stream_options.include_usage and the correct max_completion_tokens.
+    const request: AnthropicRequest = {
+      model: 'o1-mini',
+      stream: true,
+      max_tokens: 8192,
+      messages: [{ role: 'user', content: 'Hello' }]
+    }
+
+    const result = convertAnthropicToOpenAIChat(request)
+
+    expect(result.request.stream_options).toEqual({ include_usage: true })
+  })
+})
+
+describe('Responses API — stream_options.include_usage (issue #181)', () => {
+  it('injects stream_options.include_usage when stream is true', () => {
+    // The Responses API mirrors the Chat Completions streaming contract: the
+    // final streamed event only carries usage when stream_options.include_usage
+    // is explicitly set. Without it, the TokenUsageIndicator stays at zero.
+    const request: AnthropicRequest = {
+      model: 'claude-3-opus',
+      stream: true,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.stream).toBe(true)
+    expect(result.request.stream_options).toEqual({ include_usage: true })
+  })
+
+  it('omits stream_options when stream is false', () => {
+    const request: AnthropicRequest = {
+      model: 'claude-3-opus',
+      stream: false,
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.stream).toBe(false)
+    expect(result.request.stream_options).toBeUndefined()
+  })
+
+  it('omits stream_options when stream is not set (default falsy)', () => {
+    const request: AnthropicRequest = {
+      model: 'claude-3-opus',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.stream).toBeFalsy()
+    expect(result.request.stream_options).toBeUndefined()
+  })
+})

--- a/tests/unit/services/openai-compat-stream-options.test.ts
+++ b/tests/unit/services/openai-compat-stream-options.test.ts
@@ -72,10 +72,9 @@ describe('Chat Completions — stream_options.include_usage (issue #181)', () =>
     expect(result.request.stream_options).toBeUndefined()
   })
 
-  it('injects stream_options.include_usage alongside reasoning model routing', () => {
-    // Sanity check: streaming and reasoning-model detection are orthogonal.
-    // A streaming reasoning model request must carry both
-    // stream_options.include_usage and the correct max_completion_tokens.
+  it('injects stream_options.include_usage for reasoning model requests', () => {
+    // Sanity check: streaming and model id are orthogonal — the stream_options
+    // contract must hold for reasoning models too, not just standard ones.
     const request: AnthropicRequest = {
       model: 'o1-mini',
       stream: true,
@@ -91,9 +90,10 @@ describe('Chat Completions — stream_options.include_usage (issue #181)', () =>
 
 describe('Responses API — stream_options.include_usage (issue #181)', () => {
   it('injects stream_options.include_usage when stream is true', () => {
-    // The Responses API mirrors the Chat Completions streaming contract: the
-    // final streamed event only carries usage when stream_options.include_usage
-    // is explicitly set. Without it, the TokenUsageIndicator stays at zero.
+    // Defensive: the native OpenAI Responses API returns usage in
+    // `response.completed` unconditionally, but translation-style gateways
+    // (litellm and similar) gate usage on stream_options.include_usage.
+    // See the converter comment for the full rationale.
     const request: AnthropicRequest = {
       model: 'claude-3-opus',
       stream: true,
@@ -132,5 +132,21 @@ describe('Responses API — stream_options.include_usage (issue #181)', () => {
 
     expect(result.request.stream).toBeFalsy()
     expect(result.request.stream_options).toBeUndefined()
+  })
+
+  it('injects stream_options.include_usage for reasoning model requests', () => {
+    // Symmetry with the Chat Completions path: model id must not affect the
+    // stream_options contract. Guards against future refactors that gate
+    // stream_options on model family.
+    const request: AnthropicRequest = {
+      model: 'o1-mini',
+      stream: true,
+      max_tokens: 8192,
+      messages: [{ role: 'user', content: 'Hello!' }]
+    }
+
+    const result = convertAnthropicToOpenAIResponses(request)
+
+    expect(result.request.stream_options).toEqual({ include_usage: true })
   })
 })

--- a/tests/unit/services/openai-compat-stream-options.test.ts
+++ b/tests/unit/services/openai-compat-stream-options.test.ts
@@ -1,18 +1,10 @@
 /**
- * Unit tests for the OpenAI-compat request converters — stream_options injection.
+ * Unit tests for the OpenAI-compat request converters — `stream_options` injection.
  *
- * Scope (issue #181):
- *   - Chat Completions path injects `stream_options: { include_usage: true }`
- *     when the request has `stream: true`, and omits it otherwise.
- *   - Responses API path mirrors the Chat Completions behavior.
- *
- * OpenAI-compatible gateways (litellm, OpenAI public API) only return usage in
- * the final streamed chunk when `stream_options.include_usage` is set; without
- * it, `chunk.usage` is always empty and the UI's TokenUsageIndicator shows
- * zeros. These tests pin the contract at the protocol boundary.
- *
- * These tests live under the canonical `tests/unit/services/` path so they
- * match the project vitest config's recursive `tests/unit/` include pattern.
+ * Issue #181: OpenAI-compat gateways (litellm, OpenAI public Chat Completions
+ * API) only emit usage in streamed chunks when `stream_options.include_usage`
+ * is set; without it, `TokenUsageIndicator` renders zeros. These tests pin
+ * the converter contract at the protocol boundary.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -24,10 +16,6 @@ import type { AnthropicRequest } from '../../../src/main/openai-compat-router/ty
 
 describe('Chat Completions — stream_options.include_usage (issue #181)', () => {
   it('injects stream_options.include_usage when stream is true', () => {
-    // The OpenAI-compat gateway omits usage from streamed chunks unless the
-    // request opts in. The converter must set stream_options.include_usage
-    // so chunk.usage is populated downstream and the TokenUsageIndicator
-    // renders real values instead of zeros.
     const request: AnthropicRequest = {
       model: 'gpt-4o',
       stream: true,
@@ -42,8 +30,6 @@ describe('Chat Completions — stream_options.include_usage (issue #181)', () =>
   })
 
   it('omits stream_options when stream is false', () => {
-    // Non-streaming responses carry usage in the top-level `usage` field, so
-    // stream_options is unnecessary and must not be injected.
     const request: AnthropicRequest = {
       model: 'gpt-4o',
       stream: false,
@@ -58,8 +44,6 @@ describe('Chat Completions — stream_options.include_usage (issue #181)', () =>
   })
 
   it('omits stream_options when stream is not set (default falsy)', () => {
-    // Anthropic's Request type marks `stream` as optional. When the caller
-    // does not opt into streaming, the converter must not add stream_options.
     const request: AnthropicRequest = {
       model: 'gpt-4o',
       max_tokens: 1024,
@@ -73,8 +57,7 @@ describe('Chat Completions — stream_options.include_usage (issue #181)', () =>
   })
 
   it('injects stream_options.include_usage for reasoning model requests', () => {
-    // Sanity check: streaming and model id are orthogonal — the stream_options
-    // contract must hold for reasoning models too, not just standard ones.
+    // Sanity check: model id must not affect the stream_options contract.
     const request: AnthropicRequest = {
       model: 'o1-mini',
       stream: true,
@@ -90,10 +73,8 @@ describe('Chat Completions — stream_options.include_usage (issue #181)', () =>
 
 describe('Responses API — stream_options.include_usage (issue #181)', () => {
   it('injects stream_options.include_usage when stream is true', () => {
-    // Defensive: the native OpenAI Responses API returns usage in
-    // `response.completed` unconditionally, but translation-style gateways
-    // (litellm and similar) gate usage on stream_options.include_usage.
-    // See the converter comment for the full rationale.
+    // See `anthropic-to-openai-responses.ts` for why this is needed despite
+    // the native Responses API returning usage unconditionally.
     const request: AnthropicRequest = {
       model: 'claude-3-opus',
       stream: true,
@@ -135,9 +116,7 @@ describe('Responses API — stream_options.include_usage (issue #181)', () => {
   })
 
   it('injects stream_options.include_usage for reasoning model requests', () => {
-    // Symmetry with the Chat Completions path: model id must not affect the
-    // stream_options contract. Guards against future refactors that gate
-    // stream_options on model family.
+    // Symmetry with the Chat Completions path.
     const request: AnthropicRequest = {
       model: 'o1-mini',
       stream: true,


### PR DESCRIPTION
## Summary
Fixes #181

- Inject `stream_options: { include_usage: true }` in the Chat Completions converter when `stream === true`
- Mirror the same injection in the Responses API converter
- Extract shared `buildStreamOptionsIncludeUsage()` so both paths apply the contract once at the protocol boundary
- Add 7 unit tests under `tests/unit/services/` covering stream-on/stream-off/unset for both converters

## Root cause
OpenAI-compatible gateways (litellm, OpenAI public API) only return token usage in the final streamed chunk when the request explicitly sets `stream_options.include_usage`. Without this flag, `chunk.usage` is empty for every streamed response, so the downstream accumulator in `openai-chat-stream.ts` sees zero tokens and the `TokenUsageIndicator` renders all zeros (input / output / cache).

Non-streaming responses are unaffected — usage travels in the top-level `usage` field.

## Test plan
- [x] 7 unit tests pass (`tests/unit/services/openai-compat-stream-options.test.ts`)
- [x] `npm run build` succeeds, no TypeScript errors
- [ ] Manual verification against a streaming OpenAI-compatible endpoint (e.g. https://api.ai-router.dev/v1 or litellm gateway)