### PR TITLE
fix: #172 WeCom Bot Secret lost after restart — match IM instances by…

### DIFF
--- a/src/main/foundation/config-encryption.ts
+++ b/src/main/foundation/config-encryption.ts
@@ -243,33 +243,52 @@ export function unmaskSentinels(
   // Legacy wecomBot
   restore(incoming.wecomBot, existing.wecomBot, 'secret')
 
-  // IM channels instances — matched by array index
+  // IM channels instances — matched by instance ID. The frontend
+  // (MessageChannelsSection.saveInstances) always sends the full instances
+  // array, and unchanged instances carry the '***' mask sentinel from
+  // getConfig(). Index-based matching would cross-contaminate or skip secrets
+  // whenever the array is reordered, appended, or partially updated.
   const iIm = (incoming.imChannels as Record<string, unknown>)?.instances as Record<string, unknown>[] | undefined
   const eIm = (existing.imChannels as Record<string, unknown>)?.instances as Record<string, unknown>[] | undefined
   if (iIm && eIm) {
-    for (let i = 0; i < iIm.length; i++) {
-      if (!eIm[i]) continue
-      restoreMap(iIm[i]?.config, eIm[i]?.config)
+    const existingById = new Map<string, Record<string, unknown>>()
+    for (const e of eIm) {
+      if (e && typeof e.id === 'string') existingById.set(e.id, e)
+    }
+    for (const inc of iIm) {
+      const id = inc?.id
+      const ext = typeof id === 'string' ? existingById.get(id) : undefined
+      restoreMap(inc?.config, ext?.config)
     }
   }
 }
 
 function restore(incoming: unknown, existing: unknown, key: string): void {
   const inc = incoming as Record<string, unknown> | undefined
+  if (!inc || inc[key] !== MASK_SENTINEL) return
   const ext = existing as Record<string, unknown> | undefined
-  if (!inc || !ext) return
-  if (inc[key] === MASK_SENTINEL && typeof ext[key] === 'string') {
+  // Persisting the literal '***' is never correct: it means "unchanged" and
+  // the consumer has no real value to use. When the existing value is absent
+  // or itself the corrupted sentinel, fall back to '' so the field carries an
+  // honest empty state (and a previously-corrupted value self-heals on save).
+  if (ext && typeof ext[key] === 'string' && ext[key] !== MASK_SENTINEL) {
     inc[key] = ext[key]
+  } else {
+    inc[key] = ''
   }
 }
 
 function restoreMap(incoming: unknown, existing: unknown): void {
   const inc = incoming as Record<string, unknown> | undefined
-  const ext = existing as Record<string, unknown> | undefined
-  if (!inc || !ext) return
+  if (!inc) return
+  const ext = (existing as Record<string, unknown> | undefined) ?? {}
   for (const k of Object.keys(inc)) {
-    if (inc[k] === MASK_SENTINEL && typeof ext[k] === 'string') {
+    if (inc[k] !== MASK_SENTINEL) continue
+    if (typeof ext[k] === 'string' && ext[k] !== MASK_SENTINEL) {
       inc[k] = ext[k]
+    } else {
+      // No real value to restore — do not persist the sentinel (see restore).
+      inc[k] = ''
     }
   }
 }

--- a/tests/unit/services/config-encryption.test.ts
+++ b/tests/unit/services/config-encryption.test.ts
@@ -267,5 +267,167 @@ describe('config-encryption', () => {
 
       expect((incoming.remoteAccess as any).password).toBe('123456')
     })
+
+    // ── IM channel instances ───────────────────────────────────────
+    // Bug #172: WeCom Bot Secret lost after restart. The frontend
+    // (MessageChannelsSection.saveInstances) sends the full instances
+    // array; unchanged instances carry `config.secret === '***'` from
+    // getConfig(). unmaskSentinels must restore each by instance ID,
+    // never persist the literal '***', and self-heal prior corruption.
+
+    it('restores IM channel instance secrets by instance ID, not array index', () => {
+      const existing = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: 'real-secret-a' } },
+            { id: 'B', type: 'wecom-bot', config: { botId: 'aib-b', secret: 'real-secret-b' } },
+          ],
+        },
+      }
+      // Incoming array reordered [B, A] with both secrets masked.
+      const incoming = {
+        imChannels: {
+          instances: [
+            { id: 'B', type: 'wecom-bot', config: { botId: 'aib-b', secret: MASK_SENTINEL } },
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+
+      unmaskSentinels(incoming as any, existing as any)
+
+      const inc = (incoming.imChannels as any).instances
+      expect(inc[0].config.secret).toBe('real-secret-b')
+      expect(inc[1].config.secret).toBe('real-secret-a')
+    })
+
+    it('preserves a new IM channel instance real secret when prepended before existing masked instance', () => {
+      const existing = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: 'real-secret-a' } },
+          ],
+        },
+      }
+      // Incoming: new B (real secret) prepended before A (masked).
+      const incoming = {
+        imChannels: {
+          instances: [
+            { id: 'B', type: 'wecom-bot', config: { botId: 'aib-b', secret: 'real-secret-b' } },
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+
+      unmaskSentinels(incoming as any, existing as any)
+
+      const inc = (incoming.imChannels as any).instances
+      expect(inc[0].config.secret).toBe('real-secret-b')
+      expect(inc[1].config.secret).toBe('real-secret-a')
+    })
+
+    it('clears IM channel instance *** to empty string when no matching existing instance exists', () => {
+      // Existing has no instance at all; incoming carries a stale '***'.
+      const existing = { imChannels: { instances: [] } }
+      const incoming = {
+        imChannels: {
+          instances: [
+            { id: 'orphan', type: 'wecom-bot', config: { botId: 'aib-x', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+
+      unmaskSentinels(incoming as any, existing as any)
+
+      expect((incoming.imChannels as any).instances[0].config.secret).toBe('')
+    })
+
+    it('self-heals a corrupted existing IM channel *** to empty string', () => {
+      // Simulates prior corruption: '***' was previously written to disk.
+      const existing = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+      const incoming = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+
+      unmaskSentinels(incoming as any, existing as any)
+
+      expect((incoming.imChannels as any).instances[0].config.secret).toBe('')
+    })
+
+    it('restoreMap clears unmatched sentinels when existing config is undefined', () => {
+      // Edge case: existing instance missing entirely (incoming references
+      // an id that does not exist). restoreMap must not leave '***' in place.
+      const existing = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: 'real-secret-a' } },
+          ],
+        },
+      }
+      const incoming = {
+        imChannels: {
+          instances: [
+            // B has no counterpart in existing.
+            { id: 'B', type: 'wecom-bot', config: { botId: 'aib-b', secret: MASK_SENTINEL } },
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+
+      unmaskSentinels(incoming as any, existing as any)
+
+      const inc = (incoming.imChannels as any).instances
+      expect(inc[0].config.secret).toBe('')
+      expect(inc[1].config.secret).toBe('real-secret-a')
+    })
+
+    it('does not mutate existing during self-heal (existing is read-only)', () => {
+      const existing = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+      const incoming = {
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: MASK_SENTINEL } },
+          ],
+        },
+      }
+      const existingBefore = JSON.parse(JSON.stringify(existing))
+
+      unmaskSentinels(incoming as any, existing as any)
+
+      // The contract states `existing` is read-only.
+      expect(existing).toEqual(existingBefore)
+    })
+
+    it('skips IM channel restore when incoming.imChannels is absent (partial update)', () => {
+      // Partial config update: only api is touched, imChannels not in incoming.
+      const existing = {
+        api: { provider: 'openai', apiKey: 'sk-real', apiUrl: '' },
+        imChannels: {
+          instances: [
+            { id: 'A', type: 'wecom-bot', config: { botId: 'aib-a', secret: 'real-secret-a' } },
+          ],
+        },
+      }
+      const incoming = { api: { provider: 'openai', apiKey: MASK_SENTINEL, apiUrl: '' } }
+
+      expect(() => unmaskSentinels(incoming as any, existing as any)).not.toThrow()
+      expect((incoming as any).api.apiKey).toBe('sk-real')
+    })
   })
 })


### PR DESCRIPTION
… ID and never persist mask sentinel

Root cause: unmaskSentinels matched IM channel instances by array index, so reordering/prepending/partial updates paired the '***' mask sentinel with the wrong existing instance (or skipped it), and the literal '***' was then persisted to disk. On restart getConfig() returned '***', maskConfigFields re-masked it to '***', and the bot authenticated with the literal string.

Fix:
- Match IM channel instances by instance ID via a Map (mirrors the renderer's existing ID-based invariant in MessageChannelsSection.handleInstanceChange).
- restore/restoreMap now fall back to '' when a sentinel has no real existing value to restore, so the literal '***' is never persisted. This also self-heals previously-corrupted configs on the next save.

Why Bot ID survived but Secret didn't: botId does not match the sensitive-key pattern, so it was never masked — it round-tripped as plaintext. secret was masked to '***' and depended entirely on the broken unmaskSentinels path.

Tests: 5 regression + 2 invariant-hardening cases added (20/20 pass).

## Related Issue
<!-- Please link the issue this PR addresses using: Fixes #issue_number -->
Fixes #

## Changes
<!-- Describe what this PR changes -->

## Testing
<!-- How did you test these changes? -->
- [ ] Ran `npm run dev`
- [ ] Tested locally with ` "test:unit"`
- [ ] Ran `npm run i18n` (if added new text)
- [ ] Ran `test:e2e:smoke` (Optional, recommended for large changes)

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
