### PR TITLE
fix: #139 carry ModelOption.supportsVision through to router to strip…

### DIFF
--- a/src/main/openai-compat-router/__tests__/converters.test.ts
+++ b/src/main/openai-compat-router/__tests__/converters.test.ts
@@ -655,6 +655,100 @@ describe('Request Converters', () => {
       expect(fco.output).not.toContain('"image"')
       expect(fco.output).toContain('ok')
     })
+
+    // Issue #139: the router receives the provider-declared
+    // ModelOption.supportsVision through the encoded BackendConfig. Models that
+    // are NOT in the built-in blacklist (so supportsVisionById would return
+    // true) must still strip images when the override says the model has no
+    // vision capability. Without this, non-multimodal custom/niche models
+    // receive image payloads and reject them with HTTP 400.
+    it('Chat path honors explicit supportsVision=false override for unknown models', () => {
+      const request: AnthropicRequest = {
+        model: 'some-novel-future-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What is this?' },
+              { type: 'image', source: PNG_SOURCE }
+            ]
+          }
+        ]
+      }
+
+      const result = convertAnthropicToOpenAIChat(request, { supportsVision: false })
+
+      expect(result.hasImages).toBe(true)
+      const content = result.request.messages[0].content as any[]
+      expect(content).toHaveLength(1)
+      expect(content[0].type).toBe('text')
+      expect(content.some((p: any) => p.type === 'image_url')).toBe(false)
+    })
+
+    it('Chat path honors explicit supportsVision=true override for blacklisted models', () => {
+      // Override wins both ways: a provider can declare a blacklisted model
+      // actually supports vision (e.g. a custom multimodal deepseek variant).
+      const request: AnthropicRequest = {
+        model: 'deepseek-chat',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'image', source: PNG_SOURCE }]
+          }
+        ]
+      }
+
+      const result = convertAnthropicToOpenAIChat(request, { supportsVision: true })
+
+      const content = result.request.messages[0].content as any[]
+      expect(content[0].type).toBe('image_url')
+    })
+
+    it('Responses path honors explicit supportsVision=false override for unknown models', () => {
+      const request: AnthropicRequest = {
+        model: 'some-novel-future-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What is this?' },
+              { type: 'image', source: PNG_SOURCE }
+            ]
+          }
+        ]
+      }
+
+      const result = convertAnthropicToOpenAIResponses(request, { supportsVision: false })
+
+      expect(result.hasImages).toBe(true)
+      const userMsg = (result.request.input as any[]).find((i) => i.role === 'user')
+      expect(userMsg).toBeDefined()
+      expect(userMsg.content.some((p: any) => p.type === 'input_image')).toBe(false)
+      expect(userMsg.content.some((p: any) => p.type === 'input_text')).toBe(true)
+    })
+
+    it('converter omits override → falls back to supportsVisionById (preserves default behavior)', () => {
+      // Sanity: when no override is passed, the heuristic still defaults
+      // unknown models to vision-capable.
+      const request: AnthropicRequest = {
+        model: 'some-novel-future-model',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'image', source: PNG_SOURCE }]
+          }
+        ]
+      }
+
+      const result = convertAnthropicToOpenAIChat(request)
+
+      const content = result.request.messages[0].content as any[]
+      expect(content[0].type).toBe('image_url')
+    })
   })
 })
 

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-chat.ts
@@ -18,15 +18,35 @@ export interface ConversionResult {
 }
 
 /**
+ * Optional conversion overrides. `supportsVision` lets the caller pass the
+ * provider-declared ModelOption.supportsVision straight through to the
+ * router's strip decision, bypassing the model-id heuristic in
+ * {@link supportsVisionById}. Undefined falls back to that heuristic.
+ * See issue #139.
+ */
+export interface ConvertOptions {
+  supportsVision?: boolean
+}
+
+/**
  * Convert Anthropic request to OpenAI Chat Completions request
  */
-export function convertAnthropicToOpenAIChat(anthropicRequest: AnthropicRequest): ConversionResult {
+export function convertAnthropicToOpenAIChat(
+  anthropicRequest: AnthropicRequest,
+  options?: ConvertOptions
+): ConversionResult {
   // Strip image blocks for non-vision models. The OpenAI Chat spec encodes
   // images as `{type:'image_url', ...}`, but strict non-vision providers
   // reject this variant entirely. Image content can leak in via tool results
   // (Read on image, screenshots, MCP image returns) or mid-conv model
   // switches — the renderer UI input gate alone is not sufficient.
-  const stripImages = !supportsVisionById(anthropicRequest.model)
+  //
+  // Prefer the provider-declared override (ModelOption.supportsVision carried
+  // through the encoded BackendConfig) over the model-id heuristic; the
+  // heuristic defaults unknown models to vision-capable and would forward
+  // images to non-vision providers, triggering HTTP 400. (#139)
+  const visionCapable = options?.supportsVision ?? supportsVisionById(anthropicRequest.model)
+  const stripImages = !visionCapable
 
   // Convert messages
   const { messages, hasImages } = convertAnthropicMessagesToOpenAIChat(

--- a/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
+++ b/src/main/openai-compat-router/converters/request/anthropic-to-openai-responses.ts
@@ -18,13 +18,29 @@ export interface ConversionResult {
 }
 
 /**
+ * Optional conversion overrides. See {@link anthropic-to-openai-chat.ts}.
+ * Same rationale as #139: provider-declared ModelOption.supportsVision wins
+ * over the model-id heuristic.
+ */
+export interface ConvertOptions {
+  supportsVision?: boolean
+}
+
+/**
  * Convert Anthropic request to OpenAI Responses API request
  */
-export function convertAnthropicToOpenAIResponses(anthropicRequest: AnthropicRequest): ConversionResult {
+export function convertAnthropicToOpenAIResponses(
+  anthropicRequest: AnthropicRequest,
+  options?: ConvertOptions
+): ConversionResult {
   // Mirror the Chat-Completions path: drop image content when the target
   // model has no vision capability so the Responses API does not reject
   // `input_image` parts. Symmetric handling keeps both paths consistent.
-  const stripImages = !supportsVisionById(anthropicRequest.model)
+  //
+  // Prefer the provider-declared override over supportsVisionById so
+  // non-blacklisted non-vision models also strip images. (#139)
+  const visionCapable = options?.supportsVision ?? supportsVisionById(anthropicRequest.model)
+  const stripImages = !visionCapable
 
   // Detect images on the original input so we can log/report accurately
   // even after stripping.

--- a/src/main/openai-compat-router/server/request-handler.ts
+++ b/src/main/openai-compat-router/server/request-handler.ts
@@ -489,9 +489,10 @@ async function handleOpenAIConversion(
 
       // Convert request
       const requestToSend = { ...anthropicRequest, stream: wantStream }
+      const visionOverride = { supportsVision: config.supportsVision }
       const openaiRequest = apiType === 'responses'
-        ? convertAnthropicToOpenAIResponses(requestToSend).request
-        : convertAnthropicToOpenAIChat(requestToSend).request
+        ? convertAnthropicToOpenAIResponses(requestToSend, visionOverride).request
+        : convertAnthropicToOpenAIChat(requestToSend, visionOverride).request
 
       const toolCount = (openaiRequest as any).tools?.length ?? 0
       console.log(`[RequestHandler] wire=${apiType} tools=${toolCount}`)
@@ -537,8 +538,8 @@ async function handleOpenAIConversion(
           // Retry with stream enabled
           wantStream = true
           const retryRequest = apiType === 'responses'
-            ? convertAnthropicToOpenAIResponses({ ...anthropicRequest, stream: true }).request
-            : convertAnthropicToOpenAIChat({ ...anthropicRequest, stream: true }).request
+            ? convertAnthropicToOpenAIResponses({ ...anthropicRequest, stream: true }, visionOverride).request
+            : convertAnthropicToOpenAIChat({ ...anthropicRequest, stream: true }, visionOverride).request
 
           // Re-apply provider adapter to retry request (reuse same headers and context)
           applyProviderAdapter(backendUrl, retryRequest as Record<string, unknown>, requestHeaders, adapterId, adapterContext)

--- a/src/main/services/agent/helpers.ts
+++ b/src/main/services/agent/helpers.ts
@@ -279,6 +279,7 @@ export async function getApiCredentials(config: ReturnType<typeof getConfig>): P
     filterContent: backendConfig.filterContent,
     adapterId: backendConfig.adapterId,
     capabilities,
+    supportsVision: modelOption?.supportsVision,
   }
 }
 
@@ -352,6 +353,7 @@ export async function getApiCredentialsForSource(
     filterContent: backendConfig.filterContent,
     adapterId: backendConfig.adapterId,
     capabilities,
+    supportsVision: modelOption?.supportsVision,
   }
 }
 
@@ -399,6 +401,7 @@ export function credentialsToBackendConfig(
     forceStream: credentials.forceStream,
     filterContent: credentials.filterContent,
     adapterId: credentials.adapterId,
+    supportsVision: credentials.supportsVision,
     ...overrides
   }
 }

--- a/src/main/services/agent/types.ts
+++ b/src/main/services/agent/types.ts
@@ -52,6 +52,13 @@ export interface ApiCredentials {
    * defaults when this is missing.
    */
   capabilities?: ResolvedModelCapabilities
+  /**
+   * Provider-declared vision capability for the chosen model. Propagated into
+   * the encoded BackendConfig so the OpenAI-compat router strips image content
+   * for non-vision models instead of letting the upstream provider reject them
+   * with HTTP 400. undefined = router falls back to supportsVisionById. (#139)
+   */
+  supportsVision?: boolean
 }
 
 // ============================================

--- a/src/shared/types/ai-sources.ts
+++ b/src/shared/types/ai-sources.ts
@@ -321,6 +321,12 @@ export interface BackendRequestConfig {
   profileArn?: string
   /** Provider adapter ID — selects a registered adapter for request/response transformations */
   adapterId?: string
+  /**
+   * Provider-declared vision capability for the target model. When present,
+   * the OpenAI-compat router uses this instead of inferring from the model id;
+   * undefined falls back to supportsVisionById. See issue #139.
+   */
+  supportsVision?: boolean
 }
 
 // ============================================================================


### PR DESCRIPTION
… images for non-vision models

The OpenAI-compat router's image filter only had access to the model id string, so it fell back to supportsVisionById heuristic (blacklist/whitelist pattern matching, unknown → vision-capable). Non-blacklisted non-vision models (custom, niche, new variants) leaked image payloads and got HTTP 400 from providers.

Carry provider-declared ModelOption.supportsVision end-to-end through the encoded BackendConfig so the router sees the authoritative value:
  - BackendRequestConfig.supportsVision (optional, backward-compatible)
  - ApiCredentials.supportsVision, populated from modelOption in both getApiCredentials() and getApiCredentialsForSource()
  - credentialsToBackendConfig() forwards it through every caller
  - Both converters accept { supportsVision? } override, preferring it over supportsVisionById; undefined falls back to the heuristic (no regression)
  - request-handler passes config.supportsVision at both conversion call sites (initial + stream retry)

## Related Issue
<!-- Please link the issue this PR addresses using: Fixes #issue_number -->
Fixes #

## Changes
<!-- Describe what this PR changes -->

## Testing
<!-- How did you test these changes? -->
- [ ] Ran `npm run dev`
- [ ] Tested locally with ` "test:unit"`
- [ ] Ran `npm run i18n` (if added new text)
- [ ] Ran `test:e2e:smoke` (Optional, recommended for large changes)

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
