### PR TITLE
fix: surface model fetch error details

### DIFF
--- a/src/main/controllers/config.controller.ts
+++ b/src/main/controllers/config.controller.ts
@@ -98,7 +98,9 @@ export async function fetchModels(
       }
     }
 
-    const err = error as Error
-    return { success: false, error: err.message }
+    return {
+      success: false,
+      code: 'MODEL_FETCH_FAILED'
+    }
   }
 }

--- a/src/main/controllers/config.controller.ts
+++ b/src/main/controllers/config.controller.ts
@@ -9,11 +9,13 @@ import {
 } from '../foundation/config.service'
 import { maskConfigFields, unmaskSentinels } from '../foundation/config-encryption'
 import { validateApiConnection, fetchModelsFromApi } from '../services/api-validator.service'
+import { ModelFetchError } from '../../shared/model-fetch-error'
 
 export interface ControllerResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string
+  code?: string
 }
 
 /**
@@ -88,6 +90,14 @@ export async function fetchModels(
     const result = await fetchModelsFromApi({ apiKey, apiUrl })
     return { success: true, data: result }
   } catch (error: unknown) {
+    if (error instanceof ModelFetchError) {
+      return {
+        success: false,
+        code: error.code,
+        ...(error.detail ? { error: error.detail } : {})
+      }
+    }
+
     const err = error as Error
     return { success: false, error: err.message }
   }

--- a/src/main/ipc/config.ts
+++ b/src/main/ipc/config.ts
@@ -6,7 +6,8 @@ import { getConfig, saveConfig } from '../foundation/config.service'
 import { getAISourceManager } from '../services/ai-sources'
 import { decryptString } from '../foundation/secure-storage.service'
 import { maskConfigFields, unmaskSentinels } from '../foundation/config-encryption'
-import { validateApiConnection, fetchModelsFromApi } from '../services/api-validator.service'
+import { validateApiConnection } from '../services/api-validator.service'
+import { fetchModels as controllerFetchModels } from '../controllers/config.controller'
 import { runConfigProbe, emitConfigChange } from '../services/health'
 import type { AISourcesConfig, AISource } from '../../shared/types'
 import { configRpc } from '../../shared/rpc/contracts/config.contract'
@@ -130,15 +131,14 @@ export function registerConfigHandlers(): void {
     // Fetch available models from API endpoint
     fetchModels: async (apiKey: string, apiUrl: string) => {
       console.log('[Settings] config:fetch-models - Fetching from:', apiUrl ? `${apiUrl.slice(0, 30)}...` : '(no url)')
-      try {
-        const result = await fetchModelsFromApi({ apiKey, apiUrl })
-        console.log('[Settings] config:fetch-models - Found', result.models.length, 'models')
-        return { success: true, data: result }
-      } catch (error: unknown) {
-        const err = error as Error
-        console.error('[Settings] config:fetch-models - Failed:', err.message)
-        return { success: false, error: err.message }
+      const response = await controllerFetchModels(apiKey, apiUrl)
+      if (response.success) {
+        const data = response.data as { models: unknown[] }
+        console.log('[Settings] config:fetch-models - Found', data.models.length, 'models')
+      } else {
+        console.error('[Settings] config:fetch-models - Failed:', response.code || 'MODEL_FETCH_FAILED')
       }
+      return response
     },
 
     // Refresh AI sources configuration (auto-detects logged-in sources)

--- a/src/main/services/api-validator.service.ts
+++ b/src/main/services/api-validator.service.ts
@@ -105,7 +105,7 @@ export async function fetchModelsFromApi(params: FetchModelsParams): Promise<Fet
     return { models }
   } catch (error) {
     if (error instanceof ModelFetchError) throw error
-    throw new ModelFetchError(modelFetchFailureFromError(error, apiKey))
+    throw new ModelFetchError(modelFetchFailureFromError(error))
   }
 }
 

--- a/src/main/services/api-validator.service.ts
+++ b/src/main/services/api-validator.service.ts
@@ -20,6 +20,11 @@ import { ensureOpenAICompatRouter, encodeBackendConfig, normalizeApiUrl } from '
 import type { BackendConfig } from '../openai-compat-router'
 import { buildSdkEnv } from './agent/sdk-config'
 import { AVAILABLE_MODELS } from '../../shared/types/ai-sources'
+import {
+  ModelFetchError,
+  modelFetchFailureFromError,
+  modelFetchFailureFromResponse
+} from '../../shared/model-fetch-error'
 import { getHeadlessElectronPath } from './agent/helpers'
 
 // Re-export normalizeApiUrl for external use (moved to router module)
@@ -65,37 +70,43 @@ export async function fetchModelsFromApi(params: FetchModelsParams): Promise<Fet
 
   console.log('[API Validator] Fetching models from:', modelsUrl)
 
-  const response = await proxyFetch(modelsUrl, {
-    method: 'GET',
-    headers: {
-      'Authorization': `Bearer ${apiKey}`,
-      'Content-Type': 'application/json'
-    },
-    signal: AbortSignal.timeout(15000)
-  })
+  try {
+    const response = await proxyFetch(modelsUrl, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      signal: AbortSignal.timeout(15000)
+    })
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch models (${response.status})`)
+    if (!response.ok) {
+      const body = await response.text()
+      throw new ModelFetchError(modelFetchFailureFromResponse(response.status, body, apiKey))
+    }
+
+    const data = await response.json()
+
+    if (!data.data || !Array.isArray(data.data)) {
+      throw new Error('Invalid API response format')
+    }
+
+    const models = data.data
+      .filter((m: any) => typeof m.id === 'string')
+      .map((m: any) => ({ id: m.id, name: m.id }))
+      .sort((a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id))
+
+    if (models.length === 0) {
+      throw new Error('No models found')
+    }
+
+    console.log(`[API Validator] Found ${models.length} models`)
+
+    return { models }
+  } catch (error) {
+    if (error instanceof ModelFetchError) throw error
+    throw new ModelFetchError(modelFetchFailureFromError(error, apiKey))
   }
-
-  const data = await response.json()
-
-  if (!data.data || !Array.isArray(data.data)) {
-    throw new Error('Invalid API response format')
-  }
-
-  const models = data.data
-    .filter((m: any) => typeof m.id === 'string')
-    .map((m: any) => ({ id: m.id, name: m.id }))
-    .sort((a: { id: string }, b: { id: string }) => a.id.localeCompare(b.id))
-
-  if (models.length === 0) {
-    throw new Error('No models found')
-  }
-
-  console.log(`[API Validator] Found ${models.length} models`)
-
-  return { models }
 }
 
 export interface ValidateApiParams {

--- a/src/renderer/components/settings/ProviderSelector.tsx
+++ b/src/renderer/components/settings/ProviderSelector.tsx
@@ -28,6 +28,7 @@ import {
   isAnthropicProvider
 } from '../../types'
 import { resolveLocalizedText } from '../../../shared/types'
+import { formatModelFetchError } from '../../utils/model-fetch-error'
 import { useTranslation, getCurrentLanguage } from '../../i18n'
 import { api } from '../../api'
 import { ModelConfigPanel } from './ModelConfigPanel'
@@ -265,7 +266,11 @@ export function ProviderSelector({
       const response = await api.fetchModels(apiKey, apiUrl)
 
       if (!response.success || !response.data) {
-        throw new Error(response.error || 'Failed to fetch models')
+        setValidationResult({
+          valid: false,
+          message: formatModelFetchError(t, response.code, response.error)
+        })
+        return
       }
 
       const { models } = response.data as { models: ModelOption[] }
@@ -277,9 +282,12 @@ export function ProviderSelector({
       }
 
       setValidationResult({ valid: true, message: t('Found ${count} models').replace('${count}', String(models.length)) })
-    } catch (error) {
-      console.error('[ProviderSelector] Failed to fetch models:', error)
-      setValidationResult({ valid: false, message: t('Failed to fetch models') })
+    } catch {
+      console.error('[ProviderSelector] Failed to fetch models')
+      setValidationResult({
+        valid: false,
+        message: formatModelFetchError(t, 'MODEL_FETCH_NETWORK')
+      })
     } finally {
       setIsFetchingModels(false)
     }
@@ -640,7 +648,7 @@ export function ProviderSelector({
                 : 'bg-red-500/10 text-red-600'
             }`}>
               {validationResult.valid ? <Check size={16} /> : <X size={16} />}
-              <span className="text-sm">{validationResult.message}</span>
+              <span className="text-sm min-w-0 break-words">{validationResult.message}</span>
             </div>
           )}
 
@@ -976,7 +984,7 @@ export function ProviderSelector({
                 : 'bg-red-500/10 text-red-600'
             }`}>
               {validationResult.valid ? <Check size={16} /> : <X size={16} />}
-              <span className="text-sm">{validationResult.message}</span>
+              <span className="text-sm min-w-0 break-words">{validationResult.message}</span>
             </div>
           )}
 

--- a/src/renderer/components/setup/ApiSetup.tsx
+++ b/src/renderer/components/setup/ApiSetup.tsx
@@ -14,6 +14,7 @@ import { Globe, ChevronDown, ArrowLeft, Eye, EyeOff, Loader2, RefreshCw, Externa
 import { AVAILABLE_MODELS, DEFAULT_MODEL, type AISourcesConfig, type AISource, type ModelOption } from '../../types'
 import { getBuiltinProvider } from '../../types'
 import { resolveLocalizedText, type LocalizedText } from '../../../shared/types'
+import { formatModelFetchError } from '../../utils/model-fetch-error'
 import { useTranslation, setLanguage, getCurrentLanguage, SUPPORTED_LOCALES, type LocaleCode } from '../../i18n'
 import type { AuthProviderConfig } from './LoginSelector'
 import { usePresetModels } from '../../hooks/usePresetModels'
@@ -140,55 +141,22 @@ export function ApiSetup({ onBack, showBack = false, preset }: ApiSetupProps) {
     setError(null)
 
     try {
-      // Construct models endpoint
-      let baseUrl = apiUrl
-      if (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1)
+      const response = await api.fetchModels(apiKey, apiUrl)
 
-      // Remove /chat/completions suffix if present (common mistake)
-      if (baseUrl.endsWith('/chat/completions')) {
-        baseUrl = baseUrl.replace(/\/chat\/completions$/, '')
+      if (!response.success || !response.data) {
+        setError(formatModelFetchError(t, response.code, response.error))
+        return
       }
 
-      const url = `${baseUrl}/models`
+      const { models } = response.data as { models: ModelOption[] }
+      const modelIds = models.map(item => item.id)
+      setFetchedModels(modelIds)
 
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${apiKey}`,
-          'Content-Type': 'application/json'
-        }
-      })
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch models (${response.status})`)
-      }
-
-      const data = await response.json()
-
-      // OpenAI compatible format: { data: [{ id: 'model-id', ... }] }
-      if (data.data && Array.isArray(data.data)) {
-        const models = data.data
-          .map((m: any) => m.id)
-          .filter((id: any) => typeof id === 'string')
-          .sort()
-
-        if (models.length === 0) {
-          throw new Error('No models found in response')
-        }
-
-        setFetchedModels(models)
-
-        // If current model is not in list (and we found models), select the first one?
-        // Or just let user decide.
-        // If current model is default generic one, maybe switch to first fetched.
-        if (models.length > 0 && (!model || model === 'gpt-4o-mini' || model === 'deepseek-chat')) {
-          setModel(models[0])
-        }
-      } else {
-        throw new Error('Invalid API response format (expected data array)')
+      if (!model || model === 'gpt-4o-mini' || model === 'deepseek-chat') {
+        setModel(modelIds[0])
       }
     } catch {
-      setError(t('Failed to fetch models. Check URL and Key.'))
+      setError(formatModelFetchError(t, 'MODEL_FETCH_NETWORK'))
     } finally {
       setIsFetchingModels(false)
     }
@@ -683,7 +651,7 @@ export function ApiSetup({ onBack, showBack = false, preset }: ApiSetupProps) {
 
         {/* Error message */}
         {error && (
-          <p className="text-center mt-4 text-sm text-red-500">{error}</p>
+          <p className="text-center mt-4 text-sm text-red-500 break-words">{error}</p>
         )}
 
         {/* Validation result */}
@@ -691,7 +659,7 @@ export function ApiSetup({ onBack, showBack = false, preset }: ApiSetupProps) {
           <div className={`mt-4 p-3 rounded-lg ${validationResult.valid ? 'bg-green-500/10 border border-green-500/30' : 'bg-red-500/10 border border-red-500/30'}`}>
             <p className={`text-sm flex items-center gap-2 ${validationResult.valid ? 'text-green-500' : 'text-red-500'}`}>
               {validationResult.valid ? <CheckCircle2 className="w-4 h-4 shrink-0" /> : <XCircle className="w-4 h-4 shrink-0" />}
-              <span>{validationResult.message}</span>
+              <span className="min-w-0 break-words">{validationResult.message}</span>
             </p>
           </div>
         )}

--- a/src/renderer/i18n/locales/de.json
+++ b/src/renderer/i18n/locales/de.json
@@ -1393,5 +1393,10 @@
   "{{name}} running": "{{name}} läuft",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} wurde installiert, aber einige gebündelte Fähigkeiten sind fehlgeschlagen.",
   "← → to switch files": "← → zum Wechseln der Dateien",
-  "🤖 AI Browser": "🤖 AI-Browser"
+  "🤖 AI Browser": "🤖 AI-Browser",
+  "Cannot reach server, check network or proxy": "Server nicht erreichbar. Netzwerk oder Proxy prüfen",
+  "Endpoint not found, check the URL": "Endpunkt nicht gefunden. URL prüfen",
+  "Invalid API Key or no permission": "Ungültiger API-Schlüssel oder keine Berechtigung",
+  "Rate limited or out of quota": "Anfragelimit erreicht oder Kontingent ausgeschöpft",
+  "Request timed out, check the server or proxy": "Zeitüberschreitung. Server oder Proxy prüfen"
 }

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1393,5 +1393,10 @@
   "Zoom in": "Zoom in",
   "Zoom in (+)": "Zoom in (+)",
   "Zoom out": "Zoom out",
-  "Zoom out (-)": "Zoom out (-)"
+  "Zoom out (-)": "Zoom out (-)",
+  "Cannot reach server, check network or proxy": "Cannot reach server, check network or proxy",
+  "Endpoint not found, check the URL": "Endpoint not found, check the URL",
+  "Invalid API Key or no permission": "Invalid API Key or no permission",
+  "Rate limited or out of quota": "Rate limited or out of quota",
+  "Request timed out, check the server or proxy": "Request timed out, check the server or proxy"
 }

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1435,5 +1435,10 @@
   "{{name}} running": "{{name}} en ejecución",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} se instaló, pero algunas habilidades incluidas fallaron.",
   "← → to switch files": "← → para cambiar archivos",
-  "🤖 AI Browser": "🤖 Navegador IA"
+  "🤖 AI Browser": "🤖 Navegador IA",
+  "Cannot reach server, check network or proxy": "No se puede conectar con el servidor. Comprueba la red o el proxy",
+  "Endpoint not found, check the URL": "No se encontró el endpoint. Comprueba la URL",
+  "Invalid API Key or no permission": "Clave API no válida o sin permisos",
+  "Rate limited or out of quota": "Límite de solicitudes alcanzado o cuota agotada",
+  "Request timed out, check the server or proxy": "La solicitud agotó el tiempo de espera. Comprueba el servidor o el proxy"
 }

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1435,5 +1435,10 @@
   "{{name}} running": "{{name}} en cours d'exécution",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} a été installé, mais certaines compétences regroupées ont échoué.",
   "← → to switch files": "← → pour changer de fichier",
-  "🤖 AI Browser": "🤖 Navigateur IA"
+  "🤖 AI Browser": "🤖 Navigateur IA",
+  "Cannot reach server, check network or proxy": "Impossible de joindre le serveur. Vérifiez le réseau ou le proxy",
+  "Endpoint not found, check the URL": "Point de terminaison introuvable. Vérifiez l’URL",
+  "Invalid API Key or no permission": "Clé API invalide ou autorisation insuffisante",
+  "Rate limited or out of quota": "Limite de requêtes atteinte ou quota épuisé",
+  "Request timed out, check the server or proxy": "La requête a expiré. Vérifiez le serveur ou le proxy"
 }

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -1393,5 +1393,10 @@
   "{{name}} running": "{{name}} 実行中",
   "{{name}} was installed, but some bundled skills failed.": "{{name}}をインストールしましたが、一部のバンドルスキルに失敗しました。",
   "← → to switch files": "← → でファイルを切り替え",
-  "🤖 AI Browser": "🤖 AIブラウザ"
+  "🤖 AI Browser": "🤖 AIブラウザ",
+  "Cannot reach server, check network or proxy": "サーバーに接続できません。ネットワークまたはプロキシを確認してください",
+  "Endpoint not found, check the URL": "エンドポイントが見つかりません。URLを確認してください",
+  "Invalid API Key or no permission": "APIキーが無効か、権限がありません",
+  "Rate limited or out of quota": "レート制限に達したか、クォータを使い切りました",
+  "Request timed out, check the server or proxy": "リクエストがタイムアウトしました。サーバーまたはプロキシを確認してください"
 }

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1393,5 +1393,10 @@
   "{{name}} running": "{{name}} 运行中",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} 已安装，但部分捆绑技能安装失败。",
   "← → to switch files": "← → 切换文件",
-  "🤖 AI Browser": "🤖 AI 浏览器"
+  "🤖 AI Browser": "🤖 AI 浏览器",
+  "Cannot reach server, check network or proxy": "无法连接服务器，请检查网络或代理",
+  "Endpoint not found, check the URL": "未找到端点，请检查 URL",
+  "Invalid API Key or no permission": "API 密钥无效或没有权限",
+  "Rate limited or out of quota": "请求频率受限或配额已用尽",
+  "Request timed out, check the server or proxy": "请求超时，请检查服务器或代理"
 }

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -1393,5 +1393,10 @@
   "{{name}} running": "{{name}} 正在執行",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} 已安裝，但部分捆綁技能失敗。",
   "← → to switch files": "← → 切換檔案",
-  "🤖 AI Browser": "🤖 AI 瀏覽器"
+  "🤖 AI Browser": "🤖 AI 瀏覽器",
+  "Cannot reach server, check network or proxy": "無法連線至伺服器，請檢查網路或代理伺服器",
+  "Endpoint not found, check the URL": "找不到端點，請檢查 URL",
+  "Invalid API Key or no permission": "API 金鑰無效或沒有權限",
+  "Rate limited or out of quota": "請求頻率受限或配額已用盡",
+  "Request timed out, check the server or proxy": "請求逾時，請檢查伺服器或代理伺服器"
 }

--- a/src/renderer/utils/model-fetch-error.ts
+++ b/src/renderer/utils/model-fetch-error.ts
@@ -1,0 +1,33 @@
+import type { ModelFetchErrorCode } from '../../shared/model-fetch-error'
+
+type Translate = (text: string) => string
+
+export function formatModelFetchError(
+  t: Translate,
+  code?: string,
+  detail?: string
+): string {
+  let message: string
+
+  switch (code as ModelFetchErrorCode) {
+    case 'MODEL_FETCH_UNAUTHORIZED':
+      message = t('Invalid API Key or no permission')
+      break
+    case 'MODEL_FETCH_NOT_FOUND':
+      message = t('Endpoint not found, check the URL')
+      break
+    case 'MODEL_FETCH_RATE_LIMITED':
+      message = t('Rate limited or out of quota')
+      break
+    case 'MODEL_FETCH_TIMEOUT':
+      message = t('Request timed out, check the server or proxy')
+      break
+    case 'MODEL_FETCH_NETWORK':
+      message = t('Cannot reach server, check network or proxy')
+      break
+    default:
+      message = t('Failed to fetch models')
+  }
+
+  return detail ? `${message}: ${detail}` : message
+}

--- a/src/shared/model-fetch-error.ts
+++ b/src/shared/model-fetch-error.ts
@@ -59,8 +59,15 @@ export function modelFetchFailureFromResponse(
   let detail: string | undefined
 
   try {
-    const parsed = JSON.parse(body) as { error?: { message?: unknown } }
-    detail = sanitizeDetail(parsed.error?.message, apiKey)
+    const parsed = JSON.parse(body) as {
+      error?: { message?: unknown }
+      message?: unknown
+    }
+    const nestedMessage = parsed.error?.message
+    detail = sanitizeDetail(
+      typeof nestedMessage === 'string' ? nestedMessage : parsed.message,
+      apiKey
+    )
   } catch {
     detail = undefined
   }
@@ -68,10 +75,7 @@ export function modelFetchFailureFromResponse(
   return { code: codeForStatus(status), detail }
 }
 
-export function modelFetchFailureFromError(
-  error: unknown,
-  apiKey: string
-): ModelFetchFailure {
+export function modelFetchFailureFromError(error: unknown): ModelFetchFailure {
   const name = error instanceof Error ? error.name : ''
   const message = error instanceof Error ? error.message : ''
   const normalized = `${name} ${message}`.toLowerCase()
@@ -82,20 +86,14 @@ export function modelFetchFailureFromError(
     || normalized.includes('aborted')
 
   if (isTimeout) {
-    return {
-      code: 'MODEL_FETCH_TIMEOUT',
-      detail: sanitizeDetail(message, apiKey)
-    }
+    return { code: 'MODEL_FETCH_TIMEOUT' }
   }
 
   const isNetwork = error instanceof TypeError
     || /\b(econnrefused|econnreset|enotfound|enetunreach|ehostunreach)\b/i.test(message)
 
   if (isNetwork) {
-    return {
-      code: 'MODEL_FETCH_NETWORK',
-      detail: sanitizeDetail(message, apiKey)
-    }
+    return { code: 'MODEL_FETCH_NETWORK' }
   }
 
   return { code: 'MODEL_FETCH_FAILED' }

--- a/src/shared/model-fetch-error.ts
+++ b/src/shared/model-fetch-error.ts
@@ -1,0 +1,102 @@
+export type ModelFetchErrorCode =
+  | 'MODEL_FETCH_UNAUTHORIZED'
+  | 'MODEL_FETCH_NOT_FOUND'
+  | 'MODEL_FETCH_RATE_LIMITED'
+  | 'MODEL_FETCH_TIMEOUT'
+  | 'MODEL_FETCH_NETWORK'
+  | 'MODEL_FETCH_FAILED'
+
+export interface ModelFetchFailure {
+  code: ModelFetchErrorCode
+  detail?: string
+}
+
+const MAX_DETAIL_LENGTH = 200
+
+export class ModelFetchError extends Error {
+  readonly code: ModelFetchErrorCode
+  readonly detail?: string
+
+  constructor(failure: ModelFetchFailure) {
+    super(failure.detail || 'Failed to fetch models')
+    this.name = 'ModelFetchError'
+    this.code = failure.code
+    this.detail = failure.detail
+  }
+}
+
+function sanitizeDetail(value: unknown, apiKey: string): string | undefined {
+  if (typeof value !== 'string') return undefined
+
+  let detail = apiKey ? value.split(apiKey).join('[REDACTED]') : value
+  detail = detail
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!detail) return undefined
+
+  const characters = Array.from(detail)
+  if (characters.length > MAX_DETAIL_LENGTH) {
+    return `${characters.slice(0, MAX_DETAIL_LENGTH - 1).join('')}…`
+  }
+
+  return detail
+}
+
+function codeForStatus(status: number): ModelFetchErrorCode {
+  if (status === 401 || status === 403) return 'MODEL_FETCH_UNAUTHORIZED'
+  if (status === 404) return 'MODEL_FETCH_NOT_FOUND'
+  if (status === 429) return 'MODEL_FETCH_RATE_LIMITED'
+  return 'MODEL_FETCH_FAILED'
+}
+
+export function modelFetchFailureFromResponse(
+  status: number,
+  body: string,
+  apiKey: string
+): ModelFetchFailure {
+  let detail: string | undefined
+
+  try {
+    const parsed = JSON.parse(body) as { error?: { message?: unknown } }
+    detail = sanitizeDetail(parsed.error?.message, apiKey)
+  } catch {
+    detail = undefined
+  }
+
+  return { code: codeForStatus(status), detail }
+}
+
+export function modelFetchFailureFromError(
+  error: unknown,
+  apiKey: string
+): ModelFetchFailure {
+  const name = error instanceof Error ? error.name : ''
+  const message = error instanceof Error ? error.message : ''
+  const normalized = `${name} ${message}`.toLowerCase()
+  const isTimeout = name === 'AbortError'
+    || name === 'TimeoutError'
+    || normalized.includes('timeout')
+    || normalized.includes('timed out')
+    || normalized.includes('aborted')
+
+  if (isTimeout) {
+    return {
+      code: 'MODEL_FETCH_TIMEOUT',
+      detail: sanitizeDetail(message, apiKey)
+    }
+  }
+
+  const isNetwork = error instanceof TypeError
+    || /\b(econnrefused|econnreset|enotfound|enetunreach|ehostunreach)\b/i.test(message)
+
+  if (isNetwork) {
+    return {
+      code: 'MODEL_FETCH_NETWORK',
+      detail: sanitizeDetail(message, apiKey)
+    }
+  }
+
+  return { code: 'MODEL_FETCH_FAILED' }
+}

--- a/tests/unit/controllers/config.controller.test.ts
+++ b/tests/unit/controllers/config.controller.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ModelFetchError } from '../../../src/shared/model-fetch-error'
+
+const { fetchModelsFromApiMock } = vi.hoisted(() => ({
+  fetchModelsFromApiMock: vi.fn()
+}))
+
+vi.mock('../../../src/main/foundation/config.service', () => ({
+  getConfig: vi.fn(),
+  saveConfig: vi.fn()
+}))
+
+vi.mock('../../../src/main/foundation/config-encryption', () => ({
+  maskConfigFields: vi.fn(),
+  unmaskSentinels: vi.fn()
+}))
+
+vi.mock('../../../src/main/services/api-validator.service', () => ({
+  validateApiConnection: vi.fn(),
+  fetchModelsFromApi: fetchModelsFromApiMock
+}))
+
+import { fetchModels } from '../../../src/main/controllers/config.controller'
+
+describe('config controller model fetching', () => {
+  beforeEach(() => {
+    fetchModelsFromApiMock.mockReset()
+  })
+
+  it('preserves a stable model-fetch error code and safe detail', async () => {
+    fetchModelsFromApiMock.mockRejectedValue(new ModelFetchError({
+      code: 'MODEL_FETCH_UNAUTHORIZED',
+      detail: 'Invalid Authentication'
+    }))
+
+    await expect(fetchModels('sk-test-placeholder', 'https://example.com/v1')).resolves.toEqual({
+      success: false,
+      code: 'MODEL_FETCH_UNAUTHORIZED',
+      error: 'Invalid Authentication'
+    })
+  })
+
+  it('omits a generic duplicate detail when the provider did not send one', async () => {
+    fetchModelsFromApiMock.mockRejectedValue(new ModelFetchError({
+      code: 'MODEL_FETCH_NOT_FOUND'
+    }))
+
+    await expect(fetchModels('sk-test-placeholder', 'https://example.com/v1')).resolves.toEqual({
+      success: false,
+      code: 'MODEL_FETCH_NOT_FOUND'
+    })
+  })
+})

--- a/tests/unit/controllers/config.controller.test.ts
+++ b/tests/unit/controllers/config.controller.test.ts
@@ -50,4 +50,15 @@ describe('config controller model fetching', () => {
       code: 'MODEL_FETCH_NOT_FOUND'
     })
   })
+
+  it('omits unexpected exception messages from the response', async () => {
+    fetchModelsFromApiMock.mockRejectedValue(new Error(
+      'proxy credentials at /Users/private/config'
+    ))
+
+    await expect(fetchModels('sk-test-placeholder', 'https://example.com/v1')).resolves.toEqual({
+      success: false,
+      code: 'MODEL_FETCH_FAILED'
+    })
+  })
 })

--- a/tests/unit/ipc/config.test.ts
+++ b/tests/unit/ipc/config.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  controllerFetchModelsMock,
+  fetchModelsFromApiMock,
+  registerRawRpcHandlersMock
+} = vi.hoisted(() => ({
+  controllerFetchModelsMock: vi.fn(),
+  fetchModelsFromApiMock: vi.fn(),
+  registerRawRpcHandlersMock: vi.fn()
+}))
+
+vi.mock('../../../src/main/controllers/config.controller', () => ({
+  fetchModels: controllerFetchModelsMock
+}))
+
+vi.mock('../../../src/main/foundation/config.service', () => ({
+  getConfig: vi.fn(),
+  saveConfig: vi.fn()
+}))
+
+vi.mock('../../../src/main/services/ai-sources', () => ({
+  getAISourceManager: vi.fn()
+}))
+
+vi.mock('../../../src/main/foundation/secure-storage.service', () => ({
+  decryptString: vi.fn(value => value)
+}))
+
+vi.mock('../../../src/main/foundation/config-encryption', () => ({
+  maskConfigFields: vi.fn(value => value),
+  unmaskSentinels: vi.fn()
+}))
+
+vi.mock('../../../src/main/services/api-validator.service', () => ({
+  validateApiConnection: vi.fn(),
+  fetchModelsFromApi: fetchModelsFromApiMock
+}))
+
+vi.mock('../../../src/main/services/health', () => ({
+  runConfigProbe: vi.fn(),
+  emitConfigChange: vi.fn()
+}))
+
+vi.mock('../../../src/shared/rpc/contracts/config.contract', () => ({
+  configRpc: {}
+}))
+
+vi.mock('../../../src/main/ipc/rpc', () => ({
+  registerRawRpcHandlers: registerRawRpcHandlersMock
+}))
+
+import { registerConfigHandlers } from '../../../src/main/ipc/config'
+
+describe('config IPC model fetching', () => {
+  beforeEach(() => {
+    controllerFetchModelsMock.mockReset()
+    fetchModelsFromApiMock.mockReset()
+    registerRawRpcHandlersMock.mockReset()
+  })
+
+  it('delegates to the config controller so structured errors reach Electron', async () => {
+    const result = {
+      success: false,
+      code: 'MODEL_FETCH_UNAUTHORIZED',
+      error: 'Invalid Authentication'
+    }
+    controllerFetchModelsMock.mockResolvedValue(result)
+    fetchModelsFromApiMock.mockRejectedValue(new Error('service called directly'))
+
+    registerConfigHandlers()
+    const handlers = registerRawRpcHandlersMock.mock.calls[0][1] as {
+      fetchModels: (apiKey: string, apiUrl: string) => Promise<unknown>
+    }
+
+    await expect(handlers.fetchModels(
+      'sk-test-placeholder',
+      'https://example.com/v1'
+    )).resolves.toEqual(result)
+    expect(controllerFetchModelsMock).toHaveBeenCalledWith(
+      'sk-test-placeholder',
+      'https://example.com/v1'
+    )
+  })
+})

--- a/tests/unit/renderer/model-fetch-error-i18n.test.ts
+++ b/tests/unit/renderer/model-fetch-error-i18n.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const localeRoot = resolve(__dirname, '../../../src/renderer/i18n/locales')
+const locales = ['de', 'en', 'es', 'fr', 'ja', 'zh-CN', 'zh-TW']
+const messages = [
+  'Cannot reach server, check network or proxy',
+  'Endpoint not found, check the URL',
+  'Invalid API Key or no permission',
+  'Rate limited or out of quota',
+  'Request timed out, check the server or proxy'
+]
+
+describe('model-fetch error translations', () => {
+  it.each(locales)('provides localized guidance for %s', locale => {
+    const catalog = JSON.parse(readFileSync(
+      resolve(localeRoot, `${locale}.json`),
+      'utf8'
+    )) as Record<string, string>
+
+    for (const message of messages) {
+      expect(catalog[message]).toBeTypeOf('string')
+      expect(catalog[message]).not.toBe('')
+      if (locale !== 'en') expect(catalog[message]).not.toBe(message)
+    }
+  })
+})

--- a/tests/unit/renderer/model-fetch-error-wiring.test.ts
+++ b/tests/unit/renderer/model-fetch-error-wiring.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const sourceRoot = resolve(__dirname, '../../../src/renderer/components')
+
+function readComponent(relativePath: string): string {
+  return readFileSync(resolve(sourceRoot, relativePath), 'utf8')
+}
+
+describe('model-fetch error UI wiring', () => {
+  it('shows the structured service error in provider settings', () => {
+    const source = readComponent('settings/ProviderSelector.tsx')
+
+    expect(source).toContain(
+      'formatModelFetchError(t, response.code, response.error)'
+    )
+    expect(source).not.toContain(
+      "throw new Error(response.error || 'Failed to fetch models')"
+    )
+  })
+
+  it('uses the shared API path and structured error in onboarding', () => {
+    const source = readComponent('setup/ApiSetup.tsx')
+
+    expect(source).toContain(
+      'const response = await api.fetchModels(apiKey, apiUrl)'
+    )
+    expect(source).toContain(
+      'formatModelFetchError(t, response.code, response.error)'
+    )
+    expect(source).not.toContain('const response = await fetch(url')
+  })
+})

--- a/tests/unit/services/api-validator.service.test.ts
+++ b/tests/unit/services/api-validator.service.test.ts
@@ -98,27 +98,80 @@ describe('fetchModelsFromApi error details', () => {
     })
   })
 
-  it('classifies request failures without exposing credentials', async () => {
-    proxyFetchMock.mockRejectedValue(new TypeError('fetch failed for sk-test-placeholder'))
+  it('preserves an approved top-level provider detail', async () => {
+    proxyFetchMock.mockResolvedValue(new Response(
+      JSON.stringify({ message: 'Top-level provider detail' }),
+      { status: 500 }
+    ))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({
+      code: 'MODEL_FETCH_FAILED',
+      detail: 'Top-level provider detail'
+    })
+  })
+
+  it('prefers nested provider details and ignores non-string messages', async () => {
+    proxyFetchMock.mockResolvedValueOnce(new Response(
+      JSON.stringify({
+        error: { message: 'Nested detail' },
+        message: 'Top-level detail'
+      }),
+      { status: 500 }
+    ))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({ detail: 'Nested detail' })
+
+    proxyFetchMock.mockResolvedValueOnce(new Response(
+      JSON.stringify({ error: { message: 42 }, message: 'Top-level fallback' }),
+      { status: 500 }
+    ))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({ detail: 'Top-level fallback' })
+
+    proxyFetchMock.mockResolvedValueOnce(new Response(
+      JSON.stringify({ error: { message: { internal: true } }, message: 42 }),
+      { status: 500 }
+    ))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({ detail: undefined })
+  })
+
+  it('does not expose arbitrary request failure messages', async () => {
+    proxyFetchMock.mockRejectedValue(new TypeError('fetch failed for proxy-user:proxy-pass'))
 
     await expect(fetchModelsFromApi({
       apiKey: 'sk-test-placeholder',
       apiUrl: 'https://example.com/v1'
     })).rejects.toMatchObject({
       code: 'MODEL_FETCH_NETWORK',
-      detail: 'fetch failed for [REDACTED]'
+      detail: undefined
     })
   })
 
-  it('classifies request timeouts', async () => {
-    const timeout = new Error('The operation was aborted')
+  it('classifies request timeouts without exposing diagnostics', async () => {
+    const timeout = new Error('request to /Users/private/config timed out')
     timeout.name = 'TimeoutError'
     proxyFetchMock.mockRejectedValue(timeout)
 
     await expect(fetchModelsFromApi({
       apiKey: 'sk-test-placeholder',
       apiUrl: 'https://example.com/v1'
-    })).rejects.toMatchObject({ code: 'MODEL_FETCH_TIMEOUT' })
+    })).rejects.toMatchObject({
+      code: 'MODEL_FETCH_TIMEOUT',
+      detail: undefined
+    })
   })
 
   it('preserves successful model fetching', async () => {

--- a/tests/unit/services/api-validator.service.test.ts
+++ b/tests/unit/services/api-validator.service.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { proxyFetchMock } = vi.hoisted(() => ({
+  proxyFetchMock: vi.fn()
+}))
+
+vi.mock('../../../src/main/services/proxy-fetch', () => ({
+  proxyFetch: proxyFetchMock
+}))
+
+vi.mock('../../../src/main/services/agent/resolved-sdk', () => ({
+  getResolvedAgentSdk: vi.fn()
+}))
+
+import { fetchModelsFromApi } from '../../../src/main/services/api-validator.service'
+
+describe('fetchModelsFromApi error details', () => {
+  beforeEach(() => {
+    proxyFetchMock.mockReset()
+  })
+
+  it.each([
+    [401, 'MODEL_FETCH_UNAUTHORIZED'],
+    [403, 'MODEL_FETCH_UNAUTHORIZED'],
+    [404, 'MODEL_FETCH_NOT_FOUND'],
+    [429, 'MODEL_FETCH_RATE_LIMITED'],
+    [500, 'MODEL_FETCH_FAILED']
+  ])('classifies an HTTP %i response as %s', async (status, code) => {
+    proxyFetchMock.mockResolvedValue(new Response('{}', { status }))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({ code })
+  })
+
+  it('preserves an OpenAI-compatible provider detail', async () => {
+    proxyFetchMock.mockResolvedValue(new Response(
+      JSON.stringify({ error: { message: 'Invalid Authentication' } }),
+      { status: 401 }
+    ))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({
+      code: 'MODEL_FETCH_UNAUTHORIZED',
+      detail: 'Invalid Authentication'
+    })
+  })
+
+  it('keeps HTML-looking provider details as plain strings', async () => {
+    proxyFetchMock.mockResolvedValue(new Response(
+      JSON.stringify({ error: { message: '<strong>Denied</strong>' } }),
+      { status: 403 }
+    ))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({
+      detail: '<strong>Denied</strong>'
+    })
+  })
+
+  it('redacts, normalizes, and truncates untrusted provider details', async () => {
+    const apiKey = 'sk-test-placeholder'
+    const message = `  Invalid\n${apiKey}\t${'x'.repeat(300)}<b>plain text</b>  `
+    proxyFetchMock.mockResolvedValue(new Response(
+      JSON.stringify({ error: { message } }),
+      { status: 401 }
+    ))
+
+    let failure: unknown
+    try {
+      await fetchModelsFromApi({ apiKey, apiUrl: 'https://example.com/v1' })
+    } catch (error) {
+      failure = error
+    }
+
+    expect(failure).toMatchObject({ code: 'MODEL_FETCH_UNAUTHORIZED' })
+    const detail = (failure as { detail: string }).detail
+    expect(detail).not.toContain(apiKey)
+    expect(detail).not.toMatch(/[\n\t]/)
+    expect(Array.from(detail)).toHaveLength(200)
+    expect(detail).toContain('[REDACTED]')
+  })
+
+  it('does not expose malformed or unknown response bodies', async () => {
+    proxyFetchMock.mockResolvedValue(new Response('<html>proxy error</html>', { status: 404 }))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({
+      code: 'MODEL_FETCH_NOT_FOUND',
+      detail: undefined
+    })
+  })
+
+  it('classifies request failures without exposing credentials', async () => {
+    proxyFetchMock.mockRejectedValue(new TypeError('fetch failed for sk-test-placeholder'))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({
+      code: 'MODEL_FETCH_NETWORK',
+      detail: 'fetch failed for [REDACTED]'
+    })
+  })
+
+  it('classifies request timeouts', async () => {
+    const timeout = new Error('The operation was aborted')
+    timeout.name = 'TimeoutError'
+    proxyFetchMock.mockRejectedValue(timeout)
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).rejects.toMatchObject({ code: 'MODEL_FETCH_TIMEOUT' })
+  })
+
+  it('preserves successful model fetching', async () => {
+    proxyFetchMock.mockResolvedValue(new Response(JSON.stringify({
+      data: [{ id: 'model-z' }, { id: 'model-a' }]
+    }), { status: 200 }))
+
+    await expect(fetchModelsFromApi({
+      apiKey: 'sk-test-placeholder',
+      apiUrl: 'https://example.com/v1'
+    })).resolves.toEqual({
+      models: [
+        { id: 'model-a', name: 'model-a' },
+        { id: 'model-z', name: 'model-z' }
+      ]
+    })
+  })
+})

--- a/tests/unit/shared/model-fetch-error.test.ts
+++ b/tests/unit/shared/model-fetch-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import { formatModelFetchError } from '../../../src/renderer/utils/model-fetch-error'
+
+describe('formatModelFetchError', () => {
+  it.each([
+    ['MODEL_FETCH_UNAUTHORIZED', 'Invalid API Key or no permission'],
+    ['MODEL_FETCH_NOT_FOUND', 'Endpoint not found, check the URL'],
+    ['MODEL_FETCH_RATE_LIMITED', 'Rate limited or out of quota'],
+    ['MODEL_FETCH_TIMEOUT', 'Request timed out, check the server or proxy'],
+    ['MODEL_FETCH_NETWORK', 'Cannot reach server, check network or proxy'],
+    ['MODEL_FETCH_FAILED', 'Failed to fetch models']
+  ])('localizes %s with %s', (code, key) => {
+    const translate = vi.fn((value: string) => `translated:${value}`)
+
+    expect(formatModelFetchError(translate, code, 'Provider detail')).toBe(
+      `translated:${key}: Provider detail`
+    )
+    expect(translate).toHaveBeenCalledWith(key)
+  })
+
+  it('uses the generic localized message for an unknown code without detail', () => {
+    const translate = vi.fn((value: string) => `translated:${value}`)
+
+    expect(formatModelFetchError(translate, 'UNKNOWN')).toBe(
+      'translated:Failed to fetch models'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- preserve bounded OpenAI-compatible provider error details when model discovery fails
- classify auth, missing endpoint, rate limit, timeout, and network failures with stable error codes across HTTP and Electron IPC
- route onboarding model discovery through the existing `api.fetchModels` path and show the same localized guidance in onboarding and Settings
- redact API keys, normalize control characters, truncate details to 200 characters, and render details as plain text

Closes #246

## Testing

- `npm run test:unit -- unit/renderer/model-fetch-error-wiring.test.ts unit/renderer/model-fetch-error-i18n.test.ts unit/shared/model-fetch-error.test.ts unit/services/api-validator.service.test.ts unit/controllers/config.controller.test.ts unit/ipc/config.test.ts --reporter=dot` — 34 passed
- `npm run build` — passed
- `git diff --check` — passed
- full unit comparison — branch added 34 passing tests; the existing 256 failures are unchanged from `origin/main`
- TypeScript baseline comparison — error count matches `origin/main`, with no diagnostics in changed source files
- Mac Electron QA with a mocked OpenAI-compatible 401 response — verified `Invalid API Key or no permission: Invalid Authentication` in both onboarding and Settings at desktop and 390×844 viewport widths
