### PR TITLE
Fix: guard create-space name input against IME composition

### DIFF
--- a/src/renderer/components/space/CreateSpaceForm.tsx
+++ b/src/renderer/components/space/CreateSpaceForm.tsx
@@ -194,7 +194,7 @@ export function CreateSpaceForm({ onCreated, onCancel, compact = false }: Create
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => { if (e.key === 'Enter' && canCreate) handleCreate() }}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !e.nativeEvent.isComposing && e.keyCode !== 229 && canCreate) handleCreate() }}
           placeholder={t('My Project')}
           className={`w-full ${inputPad} text-sm bg-input rounded-lg border border-border focus:border-primary focus:outline-none transition-colors`}
         />


### PR DESCRIPTION
The create-space dialog's name input submitted on any Enter, so confirming a pinyin candidate with the macOS Chinese IME created the space prematurely. Add the same IME guard (`isComposing` / `keyCode === 229`) already used elsewhere so Enter only submits when no composition is active.