### PR TITLE
fix: separate a space's relative time from its "active" label (no more "Yesterdayactive")

### DIFF
--- a/src/renderer/i18n/locales/de.json
+++ b/src/renderer/i18n/locales/de.json
@@ -1396,6 +1396,7 @@
   "{{field}} is required": "{{field}} ist erforderlich",
   "{{name}} running": "{{name}} läuft",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} wurde installiert, aber einige gebündelte Fähigkeiten sind fehlgeschlagen.",
+  "{{time}} active": "{{time}} aktiv",
   "← → to switch files": "← → zum Wechseln der Dateien",
   "🤖 AI Browser": "🤖 AI-Browser",
   "Cannot reach server, check network or proxy": "Server nicht erreichbar. Netzwerk oder Proxy prüfen",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -64,6 +64,7 @@
   "{{field}} is required": "{{field}} is required",
   "{{name}} running": "{{name}} running",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} was installed, but some bundled skills failed.",
+  "{{time}} active": "{{time}} active",
   "← → to switch files": "← → to switch files",
   "🤖 AI Browser": "🤖 AI Browser",
   "1 file": "1 file",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1438,6 +1438,7 @@
   "{{field}} is required": "{{field}} es obligatorio",
   "{{name}} running": "{{name}} en ejecución",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} se instaló, pero algunas habilidades incluidas fallaron.",
+  "{{time}} active": "{{time}} activo",
   "← → to switch files": "← → para cambiar archivos",
   "🤖 AI Browser": "🤖 Navegador IA",
   "Cannot reach server, check network or proxy": "No se puede conectar con el servidor. Comprueba la red o el proxy",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1438,6 +1438,7 @@
   "{{field}} is required": "{{field}} est requis",
   "{{name}} running": "{{name}} en cours d'exécution",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} a été installé, mais certaines compétences regroupées ont échoué.",
+  "{{time}} active": "{{time}} actif",
   "← → to switch files": "← → pour changer de fichier",
   "🤖 AI Browser": "🤖 Navigateur IA",
   "Cannot reach server, check network or proxy": "Impossible de joindre le serveur. Vérifiez le réseau ou le proxy",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -1396,6 +1396,7 @@
   "{{field}} is required": "{{field}}は必須です",
   "{{name}} running": "{{name}} 実行中",
   "{{name}} was installed, but some bundled skills failed.": "{{name}}をインストールしましたが、一部のバンドルスキルに失敗しました。",
+  "{{time}} active": "{{time}} アクティブ",
   "← → to switch files": "← → でファイルを切り替え",
   "🤖 AI Browser": "🤖 AIブラウザ",
   "Cannot reach server, check network or proxy": "サーバーに接続できません。ネットワークまたはプロキシを確認してください",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -1396,6 +1396,7 @@
   "{{field}} is required": "{{field}} 为必填项",
   "{{name}} running": "{{name}} 运行中",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} 已安装，但部分捆绑技能安装失败。",
+  "{{time}} active": "{{time}}活跃",
   "← → to switch files": "← → 切换文件",
   "🤖 AI Browser": "🤖 AI 浏览器",
   "Cannot reach server, check network or proxy": "无法连接服务器，请检查网络或代理",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -1396,6 +1396,7 @@
   "{{field}} is required": "{{field}} 為必填欄位",
   "{{name}} running": "{{name}} 正在執行",
   "{{name}} was installed, but some bundled skills failed.": "{{name}} 已安裝，但部分捆綁技能失敗。",
+  "{{time}} active": "{{time}}使用中",
   "← → to switch files": "← → 切換檔案",
   "🤖 AI Browser": "🤖 AI 瀏覽器",
   "Cannot reach server, check network or proxy": "無法連線至伺服器，請檢查網路或代理伺服器",

--- a/src/renderer/pages/HomePage.tsx
+++ b/src/renderer/pages/HomePage.tsx
@@ -275,7 +275,7 @@ export function HomePage() {
                 <p className="text-xs text-muted-foreground mt-2">
                   {space.isMissing
                     ? t('Path unavailable. Reconnect the drive to open this space.')
-                    : `${formatTimeAgo(space.lastActiveAt || space.updatedAt)}${t('active')}`}
+                    : t('{{time}} active', { time: formatTimeAgo(space.lastActiveAt || space.updatedAt) })}
                 </p>
               </div>
             )}


### PR DESCRIPTION
## Problem

On the home screen, space cards show the relative time and the "active" status with no separator — `Yesterdayactive`, `2 days agoactive` — because the two are string-concatenated:

```tsx
`${formatTimeAgo(...)}${t('active')}`
```

## Fix

Use a single interpolated key so each locale owns the spacing and word order — a space for Latin scripts, none for CJK:

```tsx
t('{{time}} active', { time: formatTimeAgo(...) })
```

- en/fr/es/de: `{{time}} active` → "Yesterday active", "il y a 2 jours actif", …
- zh-CN/zh-TW: `{{time}}活跃` / `{{time}}使用中` → "昨天活跃" (no space, as intended for Chinese)
- ja: `{{time}} アクティブ`

The standalone `active` key is left untouched (still used by TeamPanel's "3/5 active"). Added the new key across all 7 locales.
