### PR TITLE
feat: add Atlas Cloud built-in provider

### DIFF
--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -332,6 +332,22 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     notes: 'Requires HTTP-Referer and X-Title headers. Supports model array for failover'
   },
   {
+    id: 'atlascloud',
+    name: 'Atlas Cloud',
+    authType: 'api-key',
+    apiUrl: 'https://api.atlascloud.ai/v1',
+    modelsUrl: 'https://api.atlascloud.ai/v1/models',
+    models: [
+      { id: 'deepseek-ai/deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+      { id: 'deepseek-ai/deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+      { id: 'qwen/qwen3.5-27b', name: 'Qwen3.5 27B' }
+    ],
+    description: 'Atlas Cloud OpenAI-compatible model API',
+    website: 'https://www.atlascloud.ai/',
+    region: 'global',
+    icon: 'cloud'
+  },
+  {
     id: 'requesty',
     name: 'Requesty',
     authType: 'api-key',

--- a/src/shared/types/ai-sources.ts
+++ b/src/shared/types/ai-sources.ts
@@ -73,6 +73,7 @@ export type BuiltinProviderId =
   | 'yi'
   | 'stepfun'
   | 'openrouter'
+  | 'atlascloud'
   | 'requesty'
   | 'groq'
   | 'mistral'

--- a/tests/unit/shared/providers.test.ts
+++ b/tests/unit/shared/providers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getAllProviderIds,
+  getBuiltinProvider,
+  getDefaultModel
+} from '../../../src/shared/constants/providers'
+
+describe('Atlas Cloud built-in provider', () => {
+  it('registers an OpenAI-compatible provider with dynamic model discovery', () => {
+    const provider = getBuiltinProvider('atlascloud')
+
+    expect(provider).toMatchObject({
+      id: 'atlascloud',
+      authType: 'api-key',
+      apiUrl: 'https://api.atlascloud.ai/v1',
+      modelsUrl: 'https://api.atlascloud.ai/v1/models',
+      region: 'global'
+    })
+    expect(provider?.recommended).toBeUndefined()
+    expect(getAllProviderIds()).toContain('atlascloud')
+  })
+
+  it('uses a verified Atlas Cloud text model as the default', () => {
+    expect(getDefaultModel('atlascloud')).toBe('deepseek-ai/deepseek-v4-pro')
+    expect(getBuiltinProvider('atlascloud')?.models.map(model => model.id)).toEqual([
+      'deepseek-ai/deepseek-v4-pro',
+      'deepseek-ai/deepseek-v4-flash',
+      'qwen/qwen3.5-27b'
+    ])
+  })
+})


### PR DESCRIPTION
## Related Issue

N/A - new built-in provider addition.

## Changes

Add Atlas Cloud as a built-in OpenAI-compatible provider, following the existing provider preset pattern:

- register `atlascloud` in `BuiltinProviderId`
- configure `https://api.atlascloud.ai/v1` and dynamic `/v1/models` discovery
- seed DeepSeek V4 Pro, DeepSeek V4 Flash, and Qwen3.5 27B text models
- add focused tests for provider discovery, endpoints, default model, and the seed catalog

The integration reuses Halo’s existing OpenAI-compatible router and does not require a provider-specific adapter.

## Validation

- `npx vitest run --config tests/vitest.config.ts tests/unit/shared/providers.test.ts` (2 passed)
- `npx tsc --noEmit`
- `npx electron-vite build`
- `git diff --check`
- Atlas Cloud live `/v1/models`: 121 models; all three seed model IDs confirmed

`npm ci --ignore-scripts` is currently blocked on upstream dependency state (Zod peer conflict, then missing multi-platform esbuild/rollup lock entries with `--legacy-peer-deps`). Validation used `npm install --package-lock=false --ignore-scripts --legacy-peer-deps`; the lockfile was not changed.

## Documentation

No README, documentation, logo, sponsor, credits, or partner changes.