### PR TITLE
feat(ai-sources): persist provider-supplied per-model overrides

### DIFF
--- a/src/main/services/ai-sources/manager.ts
+++ b/src/main/services/ai-sources/manager.ts
@@ -583,6 +583,9 @@ class AISourceManager {
     const availableModels: string[] = data._availableModels || []
     const modelNames: Record<string, string> = data._modelNames || {}
     const defaultModel = data._defaultModel || ''
+    const modelOverrides = data._modelOverrides as
+      | Record<string, Record<string, unknown>>
+      | undefined
 
     const builtin = getBuiltinProvider(providerType)
     const now = new Date().toISOString()
@@ -679,8 +682,9 @@ class AISourceManager {
             },
             model: defaultModel || s.model,
             availableModels: models.length > 0 ? models : s.availableModels,
+            modelOverrides: modelOverrides !== undefined ? modelOverrides : s.modelOverrides,
             updatedAt: now
-          }
+          } as AISource
         }
         return s
       })
@@ -703,6 +707,7 @@ class AISourceManager {
         },
         model: defaultModel,
         availableModels: models,
+        modelOverrides,
         createdAt: now,
         updatedAt: now
       }
@@ -911,14 +916,19 @@ class AISourceManager {
     const freshAiSources = this.getAiSourcesConfig()
     const now = new Date().toISOString()
 
+    const nextOverrides = providerData.modelOverrides as
+      | Record<string, Record<string, unknown>>
+      | undefined
+
     const updatedSources = freshAiSources.sources.map(s => {
       if (s.id !== sourceId) return s
       return {
         ...s,
         availableModels: models.length > 0 ? models : s.availableModels,
         model: providerData.model || s.model,
+        modelOverrides: nextOverrides !== undefined ? nextOverrides : s.modelOverrides,
         updatedAt: now
-      }
+      } as AISource
     })
 
     saveConfig({


### PR DESCRIPTION
## Summary

补上 `AISource.modelOverrides` 缺失的 provider 侧写入路径。

主仓已有 5 处消费方在**读** `source.modelOverrides?.[model]?.vision` 等字段（`manager.ts:422` `resolveVisionOverride`、`helpers.ts:192` agent preset 叠加、`config.service.ts:1070` CC 子进程环境签名、`InputArea.tsx:124` 输入框贴图判断、`ModelConfigPanel.tsx` UI），但主仓目前只有一条写入来源——用户在设置面板手动勾选（`ProviderSelector.tsx:312-313`）。

这个 PR 让 provider 也能在登录/刷新时预填这份数据（配合 halo-webank 的 halo-cloud provider 从服务端 `/v1/llm/models` 拉目录），用户不用再一个个手动勾。

## Changes

单文件 `src/main/services/ai-sources/manager.ts`（+12 / -2），三处写入路径全覆盖：

- **line 586-588** — OAuth 回调解析新字段 `data._modelOverrides`（与已有的 `_availableModels` / `_modelNames` / `_defaultModel` 命名一致）
- **line 685**（update 分支）+ **line 710**（create 分支）— OAuth 登录时写入 AISource
- **line 919-931** — `refreshConfig` 路径同样写入

## Compatibility

- `_modelOverrides` 是**可选字段**，`undefined` 时走条件分支 `!== undefined ? ... : s.modelOverrides` 保留原值。
- 现有三个 OAuth provider（claude / github-copilot / zhipu-coding-oauth）不塞新字段，行为完全不变。
- 用户手动配的 `modelOverrides` 不会被 `undefined` 擦掉。

## Test plan

- [ ] 用未升级的 provider 登录（如 claude），确认 AISource 里 `modelOverrides` 保持原值
- [ ] 用 halo-webank halo-cloud provider 登录，确认服务端目录里的 `vision` / `thinking` / `contextWindow` 等落进 AISource
- [ ] 修改用户手动配的 `modelOverrides` 后触发 refresh，provider 若不返回则用户配置保留；若返回则以 provider 为准
- [ ] `InputArea` 贴图能力按新写入的 `vision` 生效