### PR TITLE
fix(im): carry media both ways on the WeChat iLink channel

### DIFF
--- a/src/main/apps/runtime/im-channels/ilink-api.ts
+++ b/src/main/apps/runtime/im-channels/ilink-api.ts
@@ -3,6 +3,7 @@
  *
  * Used by:
  *   - weixin-ilink.provider.ts  (long-poll + send)
+ *   - ilink-media.ts            (CDN download / upload)
  *   - ipc/weixin-ilink.ts       (QR auth flow IPC handlers)
  *   - controllers/weixin-ilink.controller.ts (save-token / disconnect)
  *   - http/routes/index.ts      (QR auth HTTP routes)
@@ -13,6 +14,7 @@
 
 import https from 'https'
 import http from 'http'
+import type { IncomingHttpHeaders } from 'http'
 import { URL } from 'url'
 
 // ============================================
@@ -62,37 +64,56 @@ export function isSessionExpired(ret: number, errcode?: number): boolean {
   return ret === SESSION_EXPIRED_CODE || errcode === SESSION_EXPIRED_CODE
 }
 
-/**
- * Perform an HTTP(S) request and return the parsed JSON response.
- * Supports GET and POST methods. Throws on network or parse errors.
- *
- * @param signal - Optional AbortSignal for cancelling long-running requests
- *                 (e.g., the 35 s long-poll in the provider).
- */
-export function fetchJson<T>(
-  method: 'GET' | 'POST',
-  urlStr: string,
-  headers: Record<string, string>,
-  body?: unknown,
+/** Raw HTTP(S) response — headers are needed by the CDN upload flow. */
+export interface IlinkRawResponse {
+  status: number
+  headers: IncomingHttpHeaders
+  body: Buffer
+}
+
+export interface IlinkRequestOptions {
+  method: 'GET' | 'POST'
+  url: string
+  headers?: Record<string, string>
+  body?: Buffer | string
+  /** Cancels a request in flight (e.g. the 35 s long-poll on stop()). */
   signal?: AbortSignal
-): Promise<T> {
+  /** Abort once the response body grows past this size. */
+  maxBytes?: number
+  /** Abort when the socket makes no progress for this long. */
+  timeoutMs?: number
+  /**
+   * Abort this long after the request starts, whatever the socket is doing.
+   * `timeoutMs` alone cannot bound a slow-drip response that trickles bytes
+   * just often enough to keep looking alive.
+   */
+  deadlineMs?: number
+}
+
+/**
+ * Perform an HTTP(S) request and return the raw response.
+ * Used directly for binary transfers (CDN media download / upload);
+ * {@link fetchJson} builds on it for the JSON API endpoints.
+ */
+export function fetchBinary(options: IlinkRequestOptions): Promise<IlinkRawResponse> {
+  const { method, url, headers = {}, body, signal, maxBytes, timeoutMs, deadlineMs } = options
+
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       reject(new Error('Aborted'))
       return
     }
 
-    const parsedUrl = new URL(urlStr)
+    const parsedUrl = new URL(url)
     const isHttps = parsedUrl.protocol === 'https:'
     const transport = isHttps ? https : http
 
-    const bodyStr = body !== undefined ? JSON.stringify(body) : undefined
     const reqHeaders: Record<string, string> = { ...headers }
-    if (bodyStr) {
-      reqHeaders['Content-Length'] = Buffer.byteLength(bodyStr).toString()
+    if (body !== undefined) {
+      reqHeaders['Content-Length'] = Buffer.byteLength(body).toString()
     }
 
-    const options: https.RequestOptions = {
+    const requestOptions: https.RequestOptions = {
       hostname: parsedUrl.hostname,
       port: parsedUrl.port || (isHttps ? 443 : 80),
       path: parsedUrl.pathname + parsedUrl.search,
@@ -100,21 +121,55 @@ export function fetchJson<T>(
       headers: reqHeaders,
     }
 
-    const req = transport.request(options, (res) => {
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null
+
+    /** Release both timers so neither outlives the request on a pooled socket. */
+    function clearTimers(): void {
+      if (deadlineTimer) {
+        clearTimeout(deadlineTimer)
+        deadlineTimer = null
+      }
+      // Without a socket there is no timer to clear, and setTimeout would only
+      // queue a 'socket' listener on a request that will never get one.
+      if (timeoutMs !== undefined && req.socket) req.setTimeout(0)
+    }
+
+    const req = transport.request(requestOptions, (res) => {
       const chunks: Buffer[] = []
-      res.on('data', (chunk: Buffer) => chunks.push(chunk))
-      res.on('end', () => {
-        const raw = Buffer.concat(chunks).toString('utf8')
-        try {
-          resolve(JSON.parse(raw) as T)
-        } catch {
-          reject(new Error(`Invalid JSON response: ${raw.slice(0, 200)}`))
+      let received = 0
+      res.on('data', (chunk: Buffer) => {
+        received += chunk.length
+        if (maxBytes !== undefined && received > maxBytes) {
+          req.destroy(new Error(`Response exceeds ${maxBytes} bytes`))
+          return
         }
+        chunks.push(chunk)
+      })
+      res.on('end', () => {
+        clearTimers()
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
+        })
       })
       res.on('error', reject)
     })
 
     req.on('error', reject)
+    req.on('close', clearTimers)
+
+    if (timeoutMs !== undefined) {
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(new Error(`Request timed out after ${timeoutMs}ms`))
+      })
+    }
+
+    if (deadlineMs !== undefined) {
+      deadlineTimer = setTimeout(() => {
+        req.destroy(new Error(`Request exceeded the ${deadlineMs}ms deadline`))
+      }, deadlineMs)
+    }
 
     if (signal) {
       const onAbort = () => req.destroy(new Error('Aborted'))
@@ -122,7 +177,37 @@ export function fetchJson<T>(
       req.on('close', () => signal.removeEventListener('abort', onAbort))
     }
 
-    if (bodyStr) req.write(bodyStr)
+    if (body !== undefined) req.write(body)
     req.end()
   })
+}
+
+/**
+ * Perform an HTTP(S) request and return the parsed JSON response.
+ * Supports GET and POST methods. Throws on network or parse errors.
+ *
+ * @param signal - Optional AbortSignal for cancelling long-running requests
+ *                 (e.g., the 35 s long-poll in the provider).
+ */
+export async function fetchJson<T>(
+  method: 'GET' | 'POST',
+  urlStr: string,
+  headers: Record<string, string>,
+  body?: unknown,
+  signal?: AbortSignal
+): Promise<T> {
+  const res = await fetchBinary({
+    method,
+    url: urlStr,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    signal,
+  })
+
+  const raw = res.body.toString('utf8')
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    throw new Error(`Invalid JSON response: ${raw.slice(0, 200)}`)
+  }
 }

--- a/src/main/apps/runtime/im-channels/ilink-media.ts
+++ b/src/main/apps/runtime/im-channels/ilink-media.ts
@@ -1,0 +1,466 @@
+/**
+ * iLink Media — CDN media protocol for the WeChat iLink Bot integration.
+ *
+ * Owns everything between an iLink media handle and plaintext bytes:
+ * AES-128-ECB + PKCS7, the several AES key encodings the protocol uses,
+ * CDN URL construction, and the download / upload flows.
+ *
+ * Layering: sits on ilink-api.ts (transport, auth headers, constants) and is
+ * consumed by weixin-ilink.provider.ts, which only deals in local files and
+ * message envelopes and never sees ciphertext or CDN parameters.
+ *
+ * Diagnostics carry sizes, MIME, encrypt_type and key source only — never key
+ * material and never bytes of user media.
+ */
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto'
+import {
+  ILINK_BASE_URL,
+  CHANNEL_VERSION,
+  buildAuthHeaders,
+  fetchBinary,
+  fetchJson,
+  type IlinkRawResponse,
+} from './ilink-api'
+
+// ============================================
+// Constants
+// ============================================
+
+const CDN_UPLOAD_URL = 'https://novac2c.cdn.weixin.qq.com/c2c/upload'
+const CDN_DOWNLOAD_URL = 'https://novac2c.cdn.weixin.qq.com/c2c/download'
+
+const AES_BLOCK_SIZE = 16
+const AES_CIPHER = 'aes-128-ecb'
+
+/** Hard cap on a single media transfer — the payload is buffered in memory. */
+export const MAX_MEDIA_BYTES = 25 * 1024 * 1024
+
+/** Socket-inactivity budget; on its own it cannot bound a slow-drip response. */
+const DOWNLOAD_TIMEOUT_MS = 30_000
+/** Wall-clock ceiling on one download, so a trickling CDN cannot hold a slot. */
+const DOWNLOAD_DEADLINE_MS = 90_000
+const UPLOAD_TIMEOUT_MS = 120_000
+const UPLOAD_DEADLINE_MS = 180_000
+const UPLOAD_ATTEMPTS = 3
+const UPLOAD_RETRY_BASE_DELAY_MS = 500
+
+/**
+ * media_type values for getuploadurl. Deliberately distinct from the
+ * item_list `type` numbering used when sending the message.
+ */
+const UPLOAD_MEDIA_TYPE: Record<IlinkMediaKind, number> = {
+  image: 1,
+  video: 2,
+  voice: 3,
+  file: 4,
+}
+
+const LOG_TAG = '[IlinkMedia]'
+
+// ============================================
+// Types
+// ============================================
+
+/** Reference to an encrypted object on the WeChat C2C CDN. */
+export interface IlinkCdnMedia {
+  url?: string
+  encrypt_query_param?: string
+  aes_key?: string
+  encrypt_type?: number
+}
+
+/** Fields shared by image_item / voice_item / video_item / file_item. */
+export interface IlinkMediaItem {
+  media?: IlinkCdnMedia
+  aeskey?: string
+  url?: string
+}
+
+export type IlinkMediaKind = 'image' | 'voice' | 'video' | 'file'
+
+/** MIME types accepted for inline (multimodal) image input. */
+export type IlinkImageMime = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp'
+
+export interface IlinkMediaContent {
+  data: Buffer
+  mime: string
+}
+
+export interface IlinkUploadRequest {
+  baseUrl?: string
+  botToken: string
+  toUserId: string
+  kind: IlinkMediaKind
+  data: Buffer
+}
+
+export interface IlinkUploadResult {
+  media: IlinkCdnMedia
+  /** Size of the encrypted CDN object — echoed back as mid_size / file_size. */
+  ciphertextSize: number
+}
+
+interface GetUploadUrlResponse {
+  ret?: number
+  errcode?: number
+  errmsg?: string
+  upload_param?: string
+}
+
+// ============================================
+// Crypto
+// ============================================
+
+/**
+ * Decode an AES-128 key from any of the encodings the protocol uses:
+ * base64 of a hex string, base64 of the raw 16 bytes, or a bare hex string.
+ * Returns null when the value matches none of them.
+ */
+export function decodeAesKey(encoded: string): Buffer | null {
+  if (!encoded) return null
+
+  const fromBase64 = tryBase64(encoded)
+  if (fromBase64) {
+    if (fromBase64.length === AES_BLOCK_SIZE * 2) {
+      const fromHex = tryHex(fromBase64.toString('latin1'))
+      if (fromHex) return fromHex
+    }
+    if (fromBase64.length === AES_BLOCK_SIZE) return fromBase64
+  }
+
+  return tryHex(encoded)
+}
+
+/** Strip PKCS7 padding. Throws when the padding is not well-formed. */
+export function stripPkcs7(buf: Buffer): Buffer {
+  if (buf.length === 0) throw new Error('PKCS7: empty input')
+  const padding = buf[buf.length - 1]
+  if (padding < 1 || padding > AES_BLOCK_SIZE || padding > buf.length) {
+    throw new Error(`PKCS7: invalid padding value ${padding}`)
+  }
+  for (let i = buf.length - padding; i < buf.length; i++) {
+    if (buf[i] !== padding) throw new Error(`PKCS7: invalid padding at byte ${i}`)
+  }
+  return buf.subarray(0, buf.length - padding)
+}
+
+/** AES-128-ECB decrypt + PKCS7 unpad. Throws on any integrity failure. */
+export function aesEcbDecrypt(key: Buffer, ciphertext: Buffer): Buffer {
+  if (ciphertext.length === 0 || ciphertext.length % AES_BLOCK_SIZE !== 0) {
+    throw new Error(`ciphertext length ${ciphertext.length} is not a multiple of ${AES_BLOCK_SIZE}`)
+  }
+  const decipher = createDecipheriv(AES_CIPHER, key, null)
+  decipher.setAutoPadding(false)
+  const plain = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  return stripPkcs7(plain)
+}
+
+/** AES-128-ECB encrypt with PKCS7 padding. */
+export function aesEcbEncrypt(key: Buffer, plaintext: Buffer): Buffer {
+  const cipher = createCipheriv(AES_CIPHER, key, null)
+  cipher.setAutoPadding(true)
+  return Buffer.concat([cipher.update(plaintext), cipher.final()])
+}
+
+// ============================================
+// CDN URL
+// ============================================
+
+/**
+ * Build the public download URL for an inbound media handle. iLink returns the
+ * query parameter as a bare value, so it is wrapped in the key the CDN expects.
+ *
+ * `fallbackUrl` is the item-level url carried by voice_item / video_item /
+ * file_item. It substitutes for an empty `media.url` everywhere, including as
+ * the base the query parameter is appended to — an item that names its own host
+ * must not have its download redirected to the generic CDN host.
+ */
+export function mediaDownloadUrl(media: IlinkCdnMedia | undefined, fallbackUrl?: string): string {
+  const base = media?.url || fallbackUrl || ''
+  const param = media?.encrypt_query_param ?? ''
+  if (!param) return base
+
+  const target = base || CDN_DOWNLOAD_URL
+  const separator = target.includes('?') ? '&' : '?'
+  return `${target}${separator}encrypted_query_param=${encodeURIComponent(param)}`
+}
+
+// ============================================
+// MIME detection
+// ============================================
+
+/** Identify an image by magic bytes. Returns null for anything else. */
+export function detectImageMime(buf: Buffer): IlinkImageMime | null {
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg'
+  if (buf.length >= 8 && buf.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return 'image/png'
+  }
+  if (buf.length >= 6 && (buf.subarray(0, 6).toString('latin1') === 'GIF87a' || buf.subarray(0, 6).toString('latin1') === 'GIF89a')) {
+    return 'image/gif'
+  }
+  if (
+    buf.length >= 12 &&
+    buf.subarray(0, 4).toString('latin1') === 'RIFF' &&
+    buf.subarray(8, 12).toString('latin1') === 'WEBP'
+  ) {
+    return 'image/webp'
+  }
+  return null
+}
+
+const FALLBACK_MIME: Record<IlinkMediaKind, string> = {
+  image: 'image/jpeg',
+  voice: 'audio/silk',
+  video: 'video/mp4',
+  file: 'application/octet-stream',
+}
+
+// ============================================
+// Inbound download
+// ============================================
+
+/**
+ * Download and decrypt one inbound media item.
+ *
+ * Images may arrive as plaintext, so recognised image magic bytes are accepted
+ * as-is. That shortcut stays image-only: for voice/video/file the content is
+ * arbitrary binary, and successful PKCS7 unpadding is the only integrity signal.
+ */
+export async function downloadIlinkMedia(
+  item: IlinkMediaItem,
+  kind: IlinkMediaKind,
+  signal?: AbortSignal,
+): Promise<IlinkMediaContent> {
+  const media = item.media
+  const url = mediaDownloadUrl(media, item.url)
+  if (!url) throw new Error(`${kind}: media handle carries no download URL`)
+
+  const { key, source } = resolveMediaKey(item, kind)
+
+  const res = await fetchBinary({
+    method: 'GET',
+    url,
+    maxBytes: MAX_MEDIA_BYTES,
+    timeoutMs: DOWNLOAD_TIMEOUT_MS,
+    deadlineMs: DOWNLOAD_DEADLINE_MS,
+    signal,
+  })
+  if (res.status !== 200) {
+    throw new Error(`${kind}: CDN download failed with status ${res.status}`)
+  }
+
+  const raw = res.body
+  console.log(
+    `${LOG_TAG} downloaded kind=${kind} bytes=${raw.length} ` +
+    `encryptType=${media?.encrypt_type ?? 0} keySource=${source}`
+  )
+
+  if (kind === 'image') {
+    const rawMime = detectImageMime(raw)
+    if (rawMime) return { data: raw, mime: rawMime }
+  }
+
+  if (!key) {
+    throw new Error(
+      `${kind}: no usable AES key (keySource=${source} bytes=${raw.length} ` +
+      `encryptType=${media?.encrypt_type ?? 0})`
+    )
+  }
+
+  const plain = aesEcbDecrypt(key, raw)
+
+  if (kind === 'image') {
+    const mime = detectImageMime(plain)
+    if (!mime) {
+      // WeChat also carries BMP/TIFF and the like as images. Those are still
+      // worth handing over as a file; only inlining them is unsafe, and the
+      // generic MIME is what tells the caller not to.
+      console.warn(
+        `${LOG_TAG} decrypted image is not an inlineable type, staging as a file ` +
+        `(keySource=${source} bytes=${plain.length})`
+      )
+      return { data: plain, mime: FALLBACK_MIME.file }
+    }
+    console.log(`${LOG_TAG} decrypted kind=${kind} bytes=${plain.length} mime=${mime}`)
+    return { data: plain, mime }
+  }
+
+  console.log(`${LOG_TAG} decrypted kind=${kind} bytes=${plain.length}`)
+  return { data: plain, mime: FALLBACK_MIME[kind] }
+}
+
+/**
+ * The item-level `aeskey` (bare hex) and `media.aes_key` (base64 of hex) are
+ * two encodings of the same key; the item-level one wins when both are present.
+ */
+function resolveMediaKey(item: IlinkMediaItem, kind: IlinkMediaKind): {
+  key: Buffer | null
+  source: string
+} {
+  if (item.aeskey) {
+    const key = decodeAesKey(item.aeskey)
+    if (key) return { key, source: `${kind}_item.aeskey` }
+    console.warn(`${LOG_TAG} unrecognised ${kind}_item.aeskey format, falling back to media.aes_key`)
+  }
+  if (item.media?.aes_key) {
+    const key = decodeAesKey(item.media.aes_key)
+    if (key) return { key, source: 'media.aes_key' }
+    console.warn(`${LOG_TAG} unrecognised media.aes_key format for ${kind}`)
+  }
+  return { key: null, source: 'none' }
+}
+
+// ============================================
+// Outbound upload
+// ============================================
+
+/**
+ * Encrypt and upload a file to the WeChat CDN, returning the media handle to
+ * embed in a sendmessage item.
+ */
+export async function uploadIlinkMedia(req: IlinkUploadRequest): Promise<IlinkUploadResult> {
+  const { data, kind, toUserId, botToken } = req
+  if (data.length === 0) throw new Error('upload: empty file')
+  if (data.length > MAX_MEDIA_BYTES) {
+    throw new Error(`upload: file of ${data.length} bytes exceeds the ${MAX_MEDIA_BYTES} byte limit`)
+  }
+
+  const aesKey = randomBytes(AES_BLOCK_SIZE)
+  const aesKeyHex = aesKey.toString('hex')
+  const fileKeyHex = randomBytes(AES_BLOCK_SIZE).toString('hex')
+  // PKCS7 always appends a full block when the input is block-aligned.
+  const ciphertextSize = (Math.floor(data.length / AES_BLOCK_SIZE) + 1) * AES_BLOCK_SIZE
+
+  const baseUrl = req.baseUrl || ILINK_BASE_URL
+  const uploadUrlResponse = await fetchJson<GetUploadUrlResponse>(
+    'POST',
+    `${baseUrl}/ilink/bot/getuploadurl`,
+    buildAuthHeaders(botToken),
+    {
+      filekey: fileKeyHex,
+      media_type: UPLOAD_MEDIA_TYPE[kind],
+      to_user_id: toUserId,
+      rawsize: data.length,
+      rawfilemd5: createHash('md5').update(data).digest('hex'),
+      filesize: ciphertextSize,
+      no_need_thumb: true,
+      aeskey: aesKeyHex,
+      base_info: { channel_version: CHANNEL_VERSION },
+    },
+  )
+
+  const ret = uploadUrlResponse.ret ?? uploadUrlResponse.errcode ?? 0
+  if (ret !== 0) {
+    throw new Error(`getuploadurl failed: ret=${ret} msg=${uploadUrlResponse.errmsg ?? ''}`)
+  }
+  if (!uploadUrlResponse.upload_param) {
+    throw new Error('getuploadurl returned no upload_param')
+  }
+
+  const ciphertext = aesEcbEncrypt(aesKey, data)
+  const cdnUrl =
+    `${CDN_UPLOAD_URL}?encrypted_query_param=${encodeURIComponent(uploadUrlResponse.upload_param)}` +
+    `&filekey=${fileKeyHex}`
+  const downloadParam = await uploadToCdn(cdnUrl, ciphertext)
+
+  console.log(
+    `${LOG_TAG} uploaded kind=${kind} rawBytes=${data.length} cipherBytes=${ciphertext.length}`
+  )
+
+  return {
+    media: {
+      encrypt_query_param: downloadParam,
+      aes_key: Buffer.from(aesKeyHex).toString('base64'),
+      encrypt_type: 1,
+    },
+    ciphertextSize,
+  }
+}
+
+/**
+ * Upload the ciphertext. Retrying is safe because the filekey is random per
+ * call, but only transient failures earn one: a 4xx is the CDN rejecting this
+ * request, and re-sending the whole ciphertext cannot change its mind.
+ */
+async function uploadToCdn(url: string, ciphertext: Buffer): Promise<string> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= UPLOAD_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetchBinary({
+        method: 'POST',
+        url,
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: ciphertext,
+        timeoutMs: UPLOAD_TIMEOUT_MS,
+        deadlineMs: UPLOAD_DEADLINE_MS,
+      })
+      if (res.status !== 200) {
+        throw new CdnUploadError(`CDN upload failed with status ${res.status}`, res.status)
+      }
+
+      // A 200 without the param is a truncated or rewritten response rather than
+      // the CDN's verdict, so it stays retryable (plain Error, not CdnUploadError).
+      const param = readDownloadParam(res)
+      if (!param) throw new Error('CDN upload returned no download param')
+      return param
+    } catch (err) {
+      lastError = err
+      const message = err instanceof Error ? err.message : String(err)
+      if (!isRetryableUploadError(err)) {
+        console.warn(`${LOG_TAG} upload failed, not retryable: ${message}`)
+        break
+      }
+      console.warn(`${LOG_TAG} upload attempt ${attempt}/${UPLOAD_ATTEMPTS} failed: ${message}`)
+      if (attempt < UPLOAD_ATTEMPTS) {
+        await delay(UPLOAD_RETRY_BASE_DELAY_MS * attempt)
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError))
+}
+
+/** Carries the HTTP status so the retry policy can tell the CDN's answer apart. */
+class CdnUploadError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message)
+    this.name = 'CdnUploadError'
+  }
+}
+
+/** Transport failures and 429 / 5xx are worth another attempt; nothing else is. */
+function isRetryableUploadError(err: unknown): boolean {
+  if (!(err instanceof CdnUploadError)) return true
+  return err.status === 429 || err.status >= 500
+}
+
+function readDownloadParam(res: IlinkRawResponse): string {
+  const header = res.headers['x-encrypted-param']
+  const fromHeader = Array.isArray(header) ? header[0] : header
+  if (fromHeader) return fromHeader
+
+  try {
+    const parsed = JSON.parse(res.body.toString('utf8')) as { encrypt_query_param?: string }
+    return parsed.encrypt_query_param ?? ''
+  } catch {
+    return ''
+  }
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+function tryBase64(value: string): Buffer | null {
+  const decoded = Buffer.from(value, 'base64')
+  return decoded.length > 0 ? decoded : null
+}
+
+function tryHex(value: string): Buffer | null {
+  if (value.length !== AES_BLOCK_SIZE * 2 || !/^[0-9a-fA-F]+$/.test(value)) return null
+  return Buffer.from(value, 'hex')
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/main/apps/runtime/im-channels/index.ts
+++ b/src/main/apps/runtime/im-channels/index.ts
@@ -15,6 +15,7 @@ export { WecomBotProvider } from './wecom-bot.provider'
 export { WeixinIlinkBotProvider } from './weixin-ilink.provider'
 
 import { cleanupWecomTempFiles } from './wecom-bot.provider'
+import { cleanupWeixinIlinkTempFiles } from './weixin-ilink.provider'
 import type { ImChannelManager } from './manager'
 
 /**
@@ -26,6 +27,7 @@ import type { ImChannelManager } from './manager'
  */
 export function cleanupImChannelTempFiles(): void {
   cleanupWecomTempFiles()
+  cleanupWeixinIlinkTempFiles()
   // Future: cleanupFeishuTempFiles(), cleanupDingTalkTempFiles()
 }
 

--- a/src/main/apps/runtime/im-channels/media-temp-files.ts
+++ b/src/main/apps/runtime/im-channels/media-temp-files.ts
@@ -1,0 +1,64 @@
+/**
+ * apps/runtime/im-channels -- Media temp-file store
+ *
+ * Channel-agnostic staging area for inbound IM media. Adapters download and
+ * decrypt platform media, then hand the plaintext here; the runtime only ever
+ * sees the returned local path (see InboundAttachment).
+ *
+ * Files survive one agent execution and are pruned by age at startup, so no
+ * adapter has to track individual file lifetimes.
+ */
+
+import { readdirSync, statSync, unlinkSync } from 'fs'
+import { mkdir, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { sanitizeFilename } from '../../../foundation/file-naming'
+
+export interface StagedMediaFile {
+  /** Absolute path of the written file. */
+  localPath: string
+  /** Sanitized display name (the platform-supplied name is untrusted). */
+  filename: string
+}
+
+/**
+ * Write inbound media into `dir` under a collision-proof name.
+ * The caller-supplied name is sanitized — it comes off the wire.
+ */
+export async function stageMediaFile(
+  dir: string,
+  filename: string,
+  data: Buffer,
+): Promise<StagedMediaFile> {
+  await mkdir(dir, { recursive: true })
+  const safeName = sanitizeFilename(filename)
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}-${safeName}`
+  const localPath = join(dir, unique)
+  await writeFile(localPath, data)
+  return { localPath, filename: safeName }
+}
+
+/**
+ * Remove files in `dir` older than `maxAgeMs`. Returns how many were removed.
+ * Missing directories and locked files are not errors.
+ */
+export function pruneMediaTempDir(dir: string, maxAgeMs: number): number {
+  const cutoff = Date.now() - maxAgeMs
+  let cleaned = 0
+  try {
+    for (const name of readdirSync(dir)) {
+      const filePath = join(dir, name)
+      try {
+        if (statSync(filePath).mtimeMs < cutoff) {
+          unlinkSync(filePath)
+          cleaned++
+        }
+      } catch {
+        /* file may be in use or already gone */
+      }
+    }
+  } catch {
+    /* directory may not exist on first run */
+  }
+  return cleaned
+}

--- a/src/main/apps/runtime/im-channels/wecom-bot.provider.ts
+++ b/src/main/apps/runtime/im-channels/wecom-bot.provider.ts
@@ -46,8 +46,7 @@ import AiBot, {
   type Logger as SdkLogger,
   type WeComMediaType,
 } from '@wecom/aibot-node-sdk'
-import { readdirSync, statSync, unlinkSync } from 'fs'
-import { readFile, writeFile, mkdir } from 'fs/promises'
+import { readFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join, basename, extname } from 'path'
 import type {
@@ -74,6 +73,7 @@ import {
 } from './wecom-stream-session'
 import { ensureUtf8 } from './wecom-content-utf8'
 import { ConnectionArbiter } from './connection-arbiter'
+import { stageMediaFile, pruneMediaTempDir } from './media-temp-files'
 import { notifyAppEvent } from '../../../services/notification.service'
 
 // ============================================
@@ -157,29 +157,12 @@ function generateTraceId(prefix: string): string {
  * is safe to remove.
  */
 export function cleanupWecomTempFiles(): void {
-  const cutoff = Date.now() - 24 * 60 * 60 * 1000
-  let cleaned = 0
-  try {
-    const files = readdirSync(TEMP_DIR)
-    for (const f of files) {
-      const fp = join(TEMP_DIR, f)
-      try {
-        if (statSync(fp).mtimeMs < cutoff) {
-          unlinkSync(fp)
-          cleaned++
-        }
-      } catch {
-        /* file may be in use or already gone */
-      }
-    }
-    if (cleaned > 0) {
-      logEvent('_startup', 'info', 'temp_files_cleaned', {
-        cleaned,
-        dir: TEMP_DIR,
-      })
-    }
-  } catch {
-    /* directory may not exist on first run */
+  const cleaned = pruneMediaTempDir(TEMP_DIR, 24 * 60 * 60 * 1000)
+  if (cleaned > 0) {
+    logEvent('_startup', 'info', 'temp_files_cleaned', {
+      cleaned,
+      dir: TEMP_DIR,
+    })
   }
 }
 
@@ -1432,14 +1415,8 @@ class WecomBotInstance implements ImChannelInstance {
   ): Promise<void> {
     if (!this.wsClient) return
     try {
-      await mkdir(TEMP_DIR, { recursive: true })
       const { buffer, filename } = await this.wsClient.downloadFile(url, aesKey)
-      const safeBase = filename || `image_${Date.now()}.jpg`
-      const localPath = join(
-        TEMP_DIR,
-        `${Date.now()}-${Math.random().toString(36).slice(2, 6)}-${safeBase}`,
-      )
-      await writeFile(localPath, buffer)
+      const staged = await stageMediaFile(TEMP_DIR, filename || `image_${Date.now()}.jpg`, buffer)
 
       const ext = (url.split('?')[0].split('.').pop() ?? '').toLowerCase()
       const mimeMap: Record<string, ImageMediaType> = {
@@ -1450,8 +1427,8 @@ class WecomBotInstance implements ImChannelInstance {
 
       attachments.push({
         type: 'image',
-        filename: safeBase,
-        localPath,
+        filename: staged.filename,
+        localPath: staged.localPath,
         mimeType: 'image/jpeg',
       })
       images.push({
@@ -1459,11 +1436,11 @@ class WecomBotInstance implements ImChannelInstance {
         type: 'image',
         mediaType,
         data: buffer.toString('base64'),
-        name: safeBase,
+        name: staged.filename,
       })
       logEvent(this.instanceId, 'info', 'media_download_done', {
         mediaType: 'image',
-        filename: safeBase,
+        filename: staged.filename,
         bytes: buffer.length,
       })
     } catch (err) {
@@ -1485,18 +1462,12 @@ class WecomBotInstance implements ImChannelInstance {
   ): Promise<void> {
     if (!this.wsClient) return
     try {
-      await mkdir(TEMP_DIR, { recursive: true })
       const { buffer, filename } = await this.wsClient.downloadFile(url, aesKey)
-      const safeBase = filename || fallbackName
-      const localPath = join(
-        TEMP_DIR,
-        `${Date.now()}-${Math.random().toString(36).slice(2, 6)}-${safeBase}`,
-      )
-      await writeFile(localPath, buffer)
-      attachments.push({ type, filename: safeBase, localPath })
+      const staged = await stageMediaFile(TEMP_DIR, filename || fallbackName, buffer)
+      attachments.push({ type, filename: staged.filename, localPath: staged.localPath })
       logEvent(this.instanceId, 'info', 'media_download_done', {
         mediaType: type,
-        filename: safeBase,
+        filename: staged.filename,
         bytes: buffer.length,
       })
     } catch (err) {

--- a/src/main/apps/runtime/im-channels/weixin-ilink.provider.ts
+++ b/src/main/apps/runtime/im-channels/weixin-ilink.provider.ts
@@ -15,24 +15,49 @@
  * - AbortController used for clean long-poll cancellation on stop()
  * - Exponential backoff reconnect: 2s base, 30s cap, 100 attempts max
  * - context_token cache key: `${accountId}:${userId}` (accountId = ilink_bot_id)
+ * - Media rides the WeChat C2C CDN in both directions — see ilink-media.ts;
+ *   inbound handles are downloaded and staged as local files, outbound files
+ *   are uploaded and referenced from a sendmessage image/file item
+ * - An item whose media cannot be resolved degrades to a text placeholder
+ *   rather than costing the user the rest of the message
+ * - Inbound handling runs off the poll loop: serialised per chat so one
+ *   conversation stays in order, and capped process-wide so a backlog of media
+ *   cannot fan out into memory
  */
 
 import { randomUUID } from 'crypto'
+import { readFile, stat } from 'fs/promises'
+import { tmpdir } from 'os'
+import { extname, join } from 'path'
 import type {
   ImChannelProvider,
   ImChannelInstance,
   ImChannelConfigFieldDef,
   ImChannelType,
+  ImFileCapability,
 } from '../../../../shared/types/im-channel'
-import type { InboundMessage, ReplyHandle } from '../../../../shared/types/inbound-message'
+import type {
+  InboundMessage,
+  InboundAttachment,
+  ReplyHandle,
+} from '../../../../shared/types/inbound-message'
+import type { ImageAttachment, ImageMediaType } from '../../../services/agent/types'
+import { Semaphore } from '../concurrency'
 import {
   ILINK_BASE_URL,
   CHANNEL_VERSION,
-  SESSION_EXPIRED_CODE,
   buildAuthHeaders,
   isSessionExpired,
   fetchJson,
 } from './ilink-api'
+import {
+  downloadIlinkMedia,
+  uploadIlinkMedia,
+  MAX_MEDIA_BYTES,
+  type IlinkCdnMedia,
+  type IlinkMediaItem,
+} from './ilink-media'
+import { stageMediaFile, pruneMediaTempDir } from './media-temp-files'
 
 // ============================================
 // Constants
@@ -42,6 +67,59 @@ const RECONNECT_BASE_DELAY_MS = 2_000
 const RECONNECT_MAX_DELAY_MS = 30_000
 const MAX_RECONNECT_ATTEMPTS = 100
 const DEDUP_MAX_SIZE = 200
+
+/** Local temp directory for downloaded iLink media. */
+const TEMP_DIR = join(tmpdir(), 'halo-weixin-ilink')
+/** Downloaded media only has to outlive a single agent execution. */
+const TEMP_FILE_TTL_MS = 24 * 60 * 60 * 1000
+/**
+ * Cap on an image inlined as multimodal input. Base64 expands the payload by
+ * a third, so this keeps a single image inside the request-wide image budget.
+ * Larger images are still attached as files, just not inlined.
+ */
+const MAX_INLINE_IMAGE_BYTES = 2.5 * 1024 * 1024
+/**
+ * Cap on how many images from one message are inlined. Without it a single
+ * message carrying N images sends N × MAX_INLINE_IMAGE_BYTES of base64 into the
+ * model request. The rest still arrive as file attachments.
+ */
+const MAX_INLINE_IMAGES = 4
+/** File extensions sent as an image item; WeChat rejects anything else inline. */
+const IMAGE_EXTENSIONS = new Set([
+  '.jpg', '.jpeg', '.png', '.gif', '.webp',
+])
+const INLINE_IMAGE_MIMES = new Set<string>([
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+])
+const MEDIA_LABEL: Record<InboundMediaKind, string> = {
+  image: 'Image',
+  file: 'File',
+  video: 'Video',
+}
+
+/**
+ * Downloads run detached from the poll loop, so nothing else bounds how many a
+ * backlog can start at once — and each one buffers up to MAX_MEDIA_BYTES in the
+ * main process. Shared by every instance, because the memory ceiling is a
+ * property of the process, not of one account.
+ */
+const MAX_CONCURRENT_MEDIA_DOWNLOADS = 3
+const mediaDownloadSlots = new Semaphore(MAX_CONCURRENT_MEDIA_DOWNLOADS)
+
+// ============================================
+// Public temp-file cleanup
+// ============================================
+
+/**
+ * Remove stale iLink media temp files. Called once at startup by the
+ * im-channels layer.
+ */
+export function cleanupWeixinIlinkTempFiles(): void {
+  const cleaned = pruneMediaTempDir(TEMP_DIR, TEMP_FILE_TTL_MS)
+  if (cleaned > 0) {
+    console.log(`[WeixinIlink] Cleaned ${cleaned} stale temp file(s) from ${TEMP_DIR}`)
+  }
+}
 
 // ============================================
 // Provider-local types
@@ -53,13 +131,26 @@ interface WeixinIlinkConfig {
   accountId?: string   // ilink_bot_id — used as part of context_token cache key
 }
 
+/** Inbound media kinds that are downloaded and surfaced as attachments. */
+type InboundMediaKind = 'image' | 'file' | 'video'
+
+/** One entry of an inbound `item_list`; the server omits handles it has none for. */
 interface WeixinMessageItem {
-  type: 1 | 2 | 3 | 4 | 5   // 1=text, 2=image, 3=voice, 4=file, 5=video
+  type: number   // 1=text, 2=image, 3=voice, 4=file, 5=video
   text_item?: { text: string }
-  voice_item?: { text: string }
-  image_item?: Record<string, unknown>
-  file_item?: { filename?: string }
-  video_item?: Record<string, unknown>
+  voice_item?: { text?: string }
+  image_item?: IlinkMediaItem
+  /** Both name spellings are read — the server has been seen using either. */
+  file_item?: IlinkMediaItem & { file_name?: string; filename?: string }
+  video_item?: IlinkMediaItem
+}
+
+/** Outbound item_list entry — 1=text, 2=image, 4=file. */
+interface WeixinOutboundItem {
+  type: 1 | 2 | 4
+  text_item?: { text: string }
+  image_item?: { media: IlinkCdnMedia; mid_size: number }
+  file_item?: { media: IlinkCdnMedia; file_name: string; file_size: number }
 }
 
 interface WeixinMessage {
@@ -123,6 +214,13 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
   private reconnectAttempts = 0
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private pollAbortController: AbortController | null = null
+  /**
+   * Aborted when the instance goes down for good — stop(), or a fatal error.
+   * Media downloads outlive the poll iteration that dispatched them, so they
+   * cannot ride the per-poll controller, which reconnect() aborts while those
+   * downloads are still legitimately running.
+   */
+  private shutdownController = new AbortController()
   private inboundHandler: ((msg: InboundMessage, reply: ReplyHandle) => void) | null = null
 
   // context_token cache: key is `${accountId}:${userId}`, value is most recent context_token.
@@ -134,6 +232,14 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
 
   // Long-poll cursor — empty string means start from the beginning
   private updatesBuf = ''
+
+  // Tail of each chat's in-flight handling chain, keyed by chatId
+  private chatQueues = new Map<string, Promise<void>>()
+
+  readonly fileCapability: ImFileCapability = {
+    sendFile: (chatId, file) =>
+      this.sendFileToChat(chatId, file.resolvedPath, file.displayName),
+  }
 
   constructor(instanceId: string, config: WeixinIlinkConfig) {
     this.instanceId = instanceId
@@ -148,6 +254,9 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
 
   start(): void {
     this.active = true
+    if (this.shutdownController.signal.aborted) {
+      this.shutdownController = new AbortController()
+    }
     if (!this.config.botToken) {
       console.log(`[WeixinIlink:${this.instanceId}] No bot_token configured — waiting for QR login`)
       return
@@ -160,9 +269,11 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
     this.active = false
     this.connected = false
     this.abortCurrentPoll()
+    this.shutdownController.abort()
     this.inboundHandler = null
     this.contextTokens.clear()
     this.seenMessageIds = []
+    this.chatQueues.clear()
     this.updatesBuf = ''
     this.reconnectAttempts = 0
     console.log(`[WeixinIlink:${this.instanceId}] Stopped`)
@@ -243,8 +354,7 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
           console.error(
             `[WeixinIlink:${this.instanceId}] Session expired (code -14) — re-auth via QR required`
           )
-          this.connected = false
-          this.active = false
+          this.haltOnFatal()
           break
         }
 
@@ -268,11 +378,12 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
           this.updatesBuf = response.get_updates_buf
         }
 
+        // Dispatched without awaiting: handling downloads media, and the poll
+        // must be back on getupdates long before a slow CDN finishes.
         if (response.msgs && response.msgs.length > 0) {
           for (const msg of response.msgs) {
-            if (msg.message_type === 1) {
-              this.handleInboundMessage(msg)
-            }
+            if (msg.message_type !== 1) continue
+            this.dispatchInChatOrder(msg)
           }
         }
 
@@ -297,7 +408,7 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
       console.error(
         `[WeixinIlink:${this.instanceId}] Max reconnect attempts (${MAX_RECONNECT_ATTEMPTS}) reached, stopping`
       )
-      this.active = false
+      this.haltOnFatal()
       return
     }
     const delay = Math.min(
@@ -314,6 +425,19 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
     this.reconnectTimer = null
   }
 
+  /**
+   * Give up on the channel from the inside — session expiry, exhausted
+   * reconnects. Downloads still in flight are aborted rather than left to run
+   * to their deadline and stage files nothing will ever read; start() issues a
+   * fresh controller once the channel is revived.
+   */
+  private haltOnFatal(): void {
+    this.active = false
+    this.connected = false
+    this.abortCurrentPoll()
+    this.shutdownController.abort()
+  }
+
   private abortCurrentPoll(): void {
     if (this.pollAbortController) {
       this.pollAbortController.abort()
@@ -327,7 +451,34 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
 
   // ── Inbound message handling ─────────────────────────────────
 
-  private handleInboundMessage(msg: WeixinMessage): void {
+  /**
+   * Hand a message to its chat's queue. Detached handling would otherwise let a
+   * text-only message overtake an earlier one whose media is still downloading,
+   * so each conversation is serialised while separate chats still run in
+   * parallel. The tail is dropped once it drains, so the map only ever holds
+   * chats with work in flight.
+   */
+  private dispatchInChatOrder(msg: WeixinMessage): void {
+    const chatId = msg.from_user_id
+    if (!chatId) return
+
+    const tail = this.chatQueues.get(chatId) ?? Promise.resolve()
+    const next: Promise<void> = tail
+      .then(() => this.handleInboundMessage(msg))
+      .catch((err) => {
+        console.error(
+          `[WeixinIlink:${this.instanceId}] Inbound handling failed for message ` +
+          `${msg.message_id ?? 'n/a'}:`,
+          err
+        )
+      })
+      .finally(() => {
+        if (this.chatQueues.get(chatId) === next) this.chatQueues.delete(chatId)
+      })
+    this.chatQueues.set(chatId, next)
+  }
+
+  private async handleInboundMessage(msg: WeixinMessage): Promise<void> {
     if (!this.active || !this.inboundHandler) return
 
     const userId = msg.from_user_id
@@ -348,8 +499,13 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
       this.contextTokens.set(this.contextTokenKey(userId), msg.context_token)
     }
 
-    const text = this.extractText(msg)
-    console.log(`[WeixinIlink:${this.instanceId}] Inbound from=${userId} len=${text.length}`)
+    const { text, attachments, images } = await this.collectContent(msg)
+    if (!this.active || !this.inboundHandler) return
+
+    console.log(
+      `[WeixinIlink:${this.instanceId}] Inbound from=${userId} len=${text.length} ` +
+      `attachments=${attachments.length} images=${images.length}`
+    )
 
     const inbound: InboundMessage = {
       body: text,
@@ -360,6 +516,8 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
       chatId: userId,
       messageId: msgId,
       timestamp: Date.now(),
+      ...(attachments.length > 0 ? { attachments } : {}),
+      ...(images.length > 0 ? { images } : {}),
     }
 
     // Capture context_token at dispatch time — must be echoed in reply
@@ -381,42 +539,137 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
     this.inboundHandler(inbound, reply)
   }
 
-  private extractText(msg: WeixinMessage): string {
-    const items = msg.item_list ?? []
+  /**
+   * Turn the item list into message text plus downloaded media. Media failures
+   * degrade to a text placeholder so one bad item cannot cost the user the
+   * whole message.
+   */
+  private async collectContent(msg: WeixinMessage): Promise<{
+    text: string
+    attachments: InboundAttachment[]
+    images: ImageAttachment[]
+  }> {
     const parts: string[] = []
+    const attachments: InboundAttachment[] = []
+    const images: ImageAttachment[] = []
 
-    for (const item of items) {
+    for (const item of msg.item_list ?? []) {
       switch (item.type) {
         case 1:
           if (item.text_item?.text) parts.push(item.text_item.text)
           break
         case 2:
-          parts.push('[Image]')
+          parts.push(await this.collectMedia(item, 'image', attachments, images))
           break
         case 3:
-          // Use speech-to-text transcript when provided
-          if (item.voice_item?.text) parts.push(item.voice_item.text)
-          else parts.push('[Voice]')
+          // Speech-to-text transcript when the server supplies one; the audio
+          // itself is not surfaced. A voice message without a transcript is
+          // ordinary traffic, not something to report.
+          parts.push(item.voice_item?.text || '[Voice]')
           break
         case 4:
-          parts.push(`[File: ${item.file_item?.filename ?? 'unknown'}]`)
+          parts.push(await this.collectMedia(item, 'file', attachments, images))
           break
         case 5:
-          parts.push('[Video]')
+          parts.push(await this.collectMedia(item, 'video', attachments, images))
           break
         default:
+          console.warn(
+            `[WeixinIlink:${this.instanceId}] Unhandled inbound item type ${item.type}`
+          )
           parts.push(`[Unknown message type: ${item.type}]`)
       }
     }
 
-    return parts.join('\n').trim()
+    return { text: parts.join('\n').trim(), attachments, images }
+  }
+
+  /** Download one media item into the temp store and return its text label. */
+  private async collectMedia(
+    item: WeixinMessageItem,
+    kind: InboundMediaKind,
+    attachments: InboundAttachment[],
+    images: ImageAttachment[],
+  ): Promise<string> {
+    const label = MEDIA_LABEL[kind]
+    const handle = kind === 'image'
+      ? item.image_item
+      : kind === 'video' ? item.video_item : item.file_item
+    const wireName = kind === 'file'
+      ? item.file_item?.file_name || item.file_item?.filename
+      : undefined
+
+    if (!handle) {
+      console.warn(`[WeixinIlink:${this.instanceId}] Inbound ${kind} item carries no media handle`)
+      return `[${label}]`
+    }
+
+    await mediaDownloadSlots.acquire()
+    try {
+      const { data, mime } = await downloadIlinkMedia(handle, kind, this.shutdownController.signal)
+      const staged = await stageMediaFile(
+        TEMP_DIR,
+        wireName || this.defaultMediaName(kind, mime),
+        data,
+      )
+
+      attachments.push({
+        type: kind,
+        filename: staged.filename,
+        localPath: staged.localPath,
+        mimeType: mime,
+      })
+
+      if (
+        kind === 'image' &&
+        INLINE_IMAGE_MIMES.has(mime) &&
+        data.length <= MAX_INLINE_IMAGE_BYTES &&
+        images.length < MAX_INLINE_IMAGES
+      ) {
+        images.push({
+          id: `ilink_img_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          type: 'image',
+          mediaType: mime as ImageMediaType,
+          data: data.toString('base64'),
+          name: staged.filename,
+        })
+      }
+
+      console.log(
+        `[WeixinIlink:${this.instanceId}] Media ready kind=${kind} ` +
+        `name=${staged.filename} bytes=${data.length} mime=${mime}`
+      )
+      return `[${label}: ${staged.filename}]`
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(`[WeixinIlink:${this.instanceId}] Inbound ${kind} download failed: ${message}`)
+      return wireName
+        ? `[${label}: ${wireName} — download failed]`
+        : `[${label} — download failed]`
+    } finally {
+      mediaDownloadSlots.release()
+    }
+  }
+
+  private defaultMediaName(kind: InboundMediaKind, mime: string): string {
+    // An image the download could not type arrives as a generic MIME, and
+    // `.octet-stream` is not an extension anyone wants to see.
+    if (kind === 'image') {
+      return `image_${Date.now()}.${mime.startsWith('image/') ? mime.slice('image/'.length) : 'bin'}`
+    }
+    if (kind === 'video') return `video_${Date.now()}.mp4`
+    return `file_${Date.now()}`
   }
 
   // ── Send message ──────────────────────────────────────────────
 
-  private async sendMessage(
+  private sendMessage(toUserId: string, text: string, contextToken: string): Promise<void> {
+    return this.sendItems(toUserId, [{ type: 1, text_item: { text } }], contextToken)
+  }
+
+  private async sendItems(
     toUserId: string,
-    text: string,
+    itemList: WeixinOutboundItem[],
     contextToken: string
   ): Promise<void> {
     if (!this.config.botToken) {
@@ -440,7 +693,7 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
         message_type: 2,             // BOT
         message_state: 2,            // FINISH
         context_token: contextToken,
-        item_list: [{ type: 1, text_item: { text } }],
+        item_list: itemList,
       },
       base_info: { channel_version: CHANNEL_VERSION },
     }
@@ -455,8 +708,7 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
 
     const sendRetCode = response.ret ?? response.errcode ?? 0
     if (isSessionExpired(sendRetCode, response.errcode)) {
-      this.active = false
-      this.connected = false
+      this.haltOnFatal()
       throw new Error(
         `[WeixinIlink:${this.instanceId}] Session expired (code -14) — re-auth required`
       )
@@ -469,6 +721,75 @@ class WeixinIlinkBotInstance implements ImChannelInstance {
     }
 
     console.log(`[WeixinIlink:${this.instanceId}] Message sent to ${toUserId}`)
+  }
+
+  // ── Send file (CDN upload + media item) ───────────────────────
+
+  private async sendFileToChat(
+    chatId: string,
+    filePath: string,
+    displayName: string,
+  ): Promise<boolean> {
+    if (!this.config.botToken) {
+      console.warn(`[WeixinIlink:${this.instanceId}] Cannot send file: no bot_token`)
+      return false
+    }
+    const contextToken = this.contextTokens.get(this.contextTokenKey(chatId))
+    if (!contextToken) {
+      console.warn(
+        `[WeixinIlink:${this.instanceId}] Cannot send file to ${chatId}: ` +
+        'no context_token — blocked until next inbound message from user'
+      )
+      return false
+    }
+
+    try {
+      // Size is checked before reading — uploadIlinkMedia's own cap would only
+      // fire once the whole file is already resident in the main process.
+      const { size } = await stat(filePath)
+      if (size > MAX_MEDIA_BYTES) {
+        console.warn(
+          `[WeixinIlink:${this.instanceId}] Cannot send ${displayName} to ${chatId}: ` +
+          `${size} bytes exceeds the ${MAX_MEDIA_BYTES} byte limit`
+        )
+        return false
+      }
+
+      const data = await readFile(filePath)
+      // The extension is read off the name the recipient will see, so the item
+      // type and the file_name never disagree about what is being sent.
+      const asImage = IMAGE_EXTENSIONS.has(extname(displayName).toLowerCase())
+
+      const { media, ciphertextSize } = await uploadIlinkMedia({
+        baseUrl: this.config.baseUrl,
+        botToken: this.config.botToken,
+        toUserId: chatId,
+        kind: asImage ? 'image' : 'file',
+        data,
+      })
+
+      // mid_size describes the encrypted CDN object; file_size is rendered to
+      // the user as the size of their file, so it carries the raw byte count.
+      const item: WeixinOutboundItem = asImage
+        ? { type: 2, image_item: { media, mid_size: ciphertextSize } }
+        : {
+            type: 4,
+            file_item: { media, file_name: displayName, file_size: data.length },
+          }
+
+      await this.sendItems(chatId, [item], contextToken)
+      console.log(
+        `[WeixinIlink:${this.instanceId}] File sent to ${chatId}: ` +
+        `name=${displayName} bytes=${data.length} as=${asImage ? 'image' : 'file'}`
+      )
+      return true
+    } catch (err) {
+      console.error(
+        `[WeixinIlink:${this.instanceId}] sendFile failed for ${chatId} (${displayName}):`,
+        err
+      )
+      return false
+    }
   }
 
   // ── Helpers ───────────────────────────────────────────────────

--- a/src/main/foundation/file-naming.ts
+++ b/src/main/foundation/file-naming.ts
@@ -1,8 +1,9 @@
 /**
- * AI Browser Download Utilities
+ * File Naming Utilities
  *
- * Shared filename sanitization and unique path resolution used by both
- * the BrowserContext download tracking and the DaemonBrowserManager.
+ * Filename sanitization and unique path resolution for any subsystem that
+ * writes a file under a name it did not choose — browser downloads, IM media
+ * staging, and anything else fed from an untrusted source.
  */
 
 import * as path from 'path'

--- a/tests/unit/apps/runtime/im-channels/ilink-media.test.ts
+++ b/tests/unit/apps/runtime/im-channels/ilink-media.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Unit tests for apps/runtime/im-channels/ilink-media.
+ *
+ * Covers the protocol surface end to end, with only HTTP mocked:
+ *   - AES key decoding across the three encodings the protocol uses
+ *   - AES-128-ECB + PKCS7 round-trip and padding rejection
+ *   - CDN download URL construction and its fallbacks
+ *   - Image magic-byte detection (gates the raw plaintext fast path)
+ *   - download: status handling, key precedence, and the image-only fast path
+ *   - upload: media_type numbering, ciphertext size, download-param sourcing
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { IlinkRawResponse } from '../../../../../src/main/apps/runtime/im-channels/ilink-api'
+
+const fetchBinary = vi.fn()
+const fetchJson = vi.fn()
+
+vi.mock('../../../../../src/main/apps/runtime/im-channels/ilink-api', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../../src/main/apps/runtime/im-channels/ilink-api')
+  >()
+  return {
+    ...actual,
+    fetchBinary: (...args: unknown[]) => fetchBinary(...args),
+    fetchJson: (...args: unknown[]) => fetchJson(...args),
+  }
+})
+
+const {
+  decodeAesKey,
+  stripPkcs7,
+  aesEcbDecrypt,
+  aesEcbEncrypt,
+  mediaDownloadUrl,
+  detectImageMime,
+  downloadIlinkMedia,
+  uploadIlinkMedia,
+} = await import('../../../../../src/main/apps/runtime/im-channels/ilink-media')
+
+const KEY_HEX = '0123456789abcdef0123456789abcdef'
+const KEY_BYTES = Buffer.from(KEY_HEX, 'hex')
+/** A second key, so "which key was used" becomes observable through the decrypt. */
+const OTHER_KEY_HEX = 'fedcba9876543210fedcba9876543210'
+
+const PNG = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.alloc(24, 0x11),
+])
+
+/** Shape one CDN reply for the mocked transport. */
+function cdnResponse(
+  body: Buffer,
+  status = 200,
+  headers: Record<string, string> = {},
+): IlinkRawResponse {
+  return { status, headers, body }
+}
+
+beforeEach(() => {
+  fetchBinary.mockReset()
+  fetchJson.mockReset()
+})
+
+describe('decodeAesKey', () => {
+  it('decodes base64 of a hex string (outbound convention)', () => {
+    const encoded = Buffer.from(KEY_HEX).toString('base64')
+    expect(decodeAesKey(encoded)).toEqual(KEY_BYTES)
+  })
+
+  it('decodes base64 of raw 16 bytes', () => {
+    expect(decodeAesKey(KEY_BYTES.toString('base64'))).toEqual(KEY_BYTES)
+  })
+
+  it('decodes a bare hex string (inbound item aeskey)', () => {
+    expect(decodeAesKey(KEY_HEX)).toEqual(KEY_BYTES)
+  })
+
+  it('returns null for an unrecognised format', () => {
+    expect(decodeAesKey('not a key')).toBeNull()
+    expect(decodeAesKey('')).toBeNull()
+    expect(decodeAesKey('abcd')).toBeNull()
+  })
+})
+
+describe('stripPkcs7', () => {
+  it('removes the padding block', () => {
+    const padded = Buffer.concat([Buffer.from('hello'), Buffer.alloc(11, 11)])
+    expect(stripPkcs7(padded).toString()).toBe('hello')
+  })
+
+  it('rejects an out-of-range padding value', () => {
+    expect(() => stripPkcs7(Buffer.from([1, 2, 3, 99]))).toThrow(/invalid padding value/)
+    expect(() => stripPkcs7(Buffer.from([1, 2, 3, 0]))).toThrow(/invalid padding value/)
+  })
+
+  it('rejects inconsistent padding bytes', () => {
+    expect(() => stripPkcs7(Buffer.from([1, 2, 4, 3, 3]))).toThrow(/invalid padding at byte/)
+  })
+
+  it('rejects empty input', () => {
+    expect(() => stripPkcs7(Buffer.alloc(0))).toThrow(/empty input/)
+  })
+})
+
+describe('aesEcbEncrypt / aesEcbDecrypt', () => {
+  it('round-trips arbitrary bytes', () => {
+    const plain = Buffer.from('the quick brown fox jumps over the lazy dog')
+    expect(aesEcbDecrypt(KEY_BYTES, aesEcbEncrypt(KEY_BYTES, plain))).toEqual(plain)
+  })
+
+  it('appends a full padding block when the input is block-aligned', () => {
+    const plain = Buffer.alloc(32, 7)
+    const cipher = aesEcbEncrypt(KEY_BYTES, plain)
+    expect(cipher.length).toBe(48)
+    expect(aesEcbDecrypt(KEY_BYTES, cipher)).toEqual(plain)
+  })
+
+  it('rejects ciphertext that is not a multiple of the block size', () => {
+    expect(() => aesEcbDecrypt(KEY_BYTES, Buffer.alloc(20))).toThrow(/not a multiple/)
+    expect(() => aesEcbDecrypt(KEY_BYTES, Buffer.alloc(0))).toThrow(/not a multiple/)
+  })
+
+  it('rejects ciphertext decrypted with the wrong key', () => {
+    const cipher = aesEcbEncrypt(KEY_BYTES, Buffer.from('secret payload'))
+    const wrongKey = Buffer.alloc(16, 0xab)
+    expect(() => aesEcbDecrypt(wrongKey, cipher)).toThrow(/PKCS7/)
+  })
+})
+
+describe('mediaDownloadUrl', () => {
+  it('falls back to the CDN download base when the handle carries no url', () => {
+    expect(mediaDownloadUrl({ encrypt_query_param: 'abc+/=' })).toBe(
+      'https://novac2c.cdn.weixin.qq.com/c2c/download?encrypted_query_param=abc%2B%2F%3D'
+    )
+  })
+
+  it('appends to an existing query string', () => {
+    expect(mediaDownloadUrl({ url: 'https://cdn.example.com/dl?a=1', encrypt_query_param: 'p' }))
+      .toBe('https://cdn.example.com/dl?a=1&encrypted_query_param=p')
+  })
+
+  it('uses the handle url as-is when there is no query param', () => {
+    expect(mediaDownloadUrl({ url: 'https://cdn.example.com/dl' }))
+      .toBe('https://cdn.example.com/dl')
+  })
+
+  it('falls back to the item-level url', () => {
+    expect(mediaDownloadUrl({}, 'https://cdn.example.com/item'))
+      .toBe('https://cdn.example.com/item')
+    expect(mediaDownloadUrl(undefined, 'https://cdn.example.com/item'))
+      .toBe('https://cdn.example.com/item')
+  })
+
+  it('uses the item-level url as the base the query parameter is appended to', () => {
+    expect(mediaDownloadUrl({ encrypt_query_param: 'p' }, 'https://cdn.example.com/item'))
+      .toBe('https://cdn.example.com/item?encrypted_query_param=p')
+  })
+
+  it('prefers the handle url over the item-level url', () => {
+    expect(mediaDownloadUrl(
+      { url: 'https://handle.example.com/dl', encrypt_query_param: 'p' },
+      'https://cdn.example.com/item',
+    )).toBe('https://handle.example.com/dl?encrypted_query_param=p')
+  })
+
+  it('returns an empty string when nothing is available', () => {
+    expect(mediaDownloadUrl(undefined)).toBe('')
+    expect(mediaDownloadUrl({})).toBe('')
+  })
+})
+
+describe('detectImageMime', () => {
+  it('recognises the supported image formats', () => {
+    expect(detectImageMime(Buffer.from([0xff, 0xd8, 0xff, 0xe0]))).toBe('image/jpeg')
+    expect(detectImageMime(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00])))
+      .toBe('image/png')
+    expect(detectImageMime(Buffer.from('GIF89a....'))).toBe('image/gif')
+    expect(detectImageMime(Buffer.concat([
+      Buffer.from('RIFF'), Buffer.alloc(4), Buffer.from('WEBP'),
+    ]))).toBe('image/webp')
+  })
+
+  it('returns null for ciphertext-shaped bytes and short inputs', () => {
+    expect(detectImageMime(Buffer.alloc(64, 0x5a))).toBeNull()
+    expect(detectImageMime(Buffer.from([0xff, 0xd8]))).toBeNull()
+    expect(detectImageMime(Buffer.alloc(0))).toBeNull()
+  })
+})
+
+describe('downloadIlinkMedia', () => {
+  it('rejects a non-200 CDN response instead of decrypting the error body', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(Buffer.from('<html>404</html>'), 404))
+
+    await expect(
+      downloadIlinkMedia({ media: { encrypt_query_param: 'p', aes_key: KEY_HEX } }, 'image'),
+    ).rejects.toThrow(/status 404/)
+  })
+
+  it('accepts raw image bytes without a key (the image fast path)', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(PNG))
+
+    const result = await downloadIlinkMedia({ media: { encrypt_query_param: 'p' } }, 'image')
+    expect(result.mime).toBe('image/png')
+    expect(result.data).toEqual(PNG)
+  })
+
+  it('decrypts an image that did arrive encrypted', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(aesEcbEncrypt(KEY_BYTES, PNG)))
+
+    const result = await downloadIlinkMedia(
+      { media: { encrypt_query_param: 'p' }, aeskey: KEY_HEX },
+      'image',
+    )
+    expect(result.mime).toBe('image/png')
+    expect(result.data).toEqual(PNG)
+  })
+
+  it('hands over an image format it cannot inline as a generic file', async () => {
+    // A BMP: an image WeChat does carry, outside the four multimodal-safe types.
+    const bmp = Buffer.concat([Buffer.from('BM'), Buffer.alloc(30, 0x07)])
+    fetchBinary.mockResolvedValue(cdnResponse(aesEcbEncrypt(KEY_BYTES, bmp)))
+
+    const result = await downloadIlinkMedia(
+      { media: { encrypt_query_param: 'p' }, aeskey: KEY_HEX },
+      'image',
+    )
+    expect(result.data).toEqual(bmp)
+    expect(result.mime).toBe('application/octet-stream')
+  })
+
+  it('refuses the raw fast path for a file even when the bytes sniff as an image', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(PNG))
+
+    await expect(
+      downloadIlinkMedia({ media: { encrypt_query_param: 'p' } }, 'file'),
+    ).rejects.toThrow(/no usable AES key/)
+  })
+
+  it('refuses the raw fast path for voice and video too', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(PNG))
+
+    await expect(
+      downloadIlinkMedia({ media: { encrypt_query_param: 'p' } }, 'voice'),
+    ).rejects.toThrow(/no usable AES key/)
+    await expect(
+      downloadIlinkMedia({ media: { encrypt_query_param: 'p' } }, 'video'),
+    ).rejects.toThrow(/no usable AES key/)
+  })
+
+  it('decrypts a file with the item-level aeskey in preference to media.aes_key', async () => {
+    const payload = Buffer.from('%PDF-1.4 quarterly report')
+    fetchBinary.mockResolvedValue(cdnResponse(aesEcbEncrypt(KEY_BYTES, payload)))
+
+    const result = await downloadIlinkMedia(
+      {
+        media: {
+          encrypt_query_param: 'p',
+          // Would produce garbage if it were the one picked.
+          aes_key: Buffer.from(OTHER_KEY_HEX).toString('base64'),
+        },
+        aeskey: KEY_HEX,
+      },
+      'file',
+    )
+    expect(result.data).toEqual(payload)
+    expect(result.mime).toBe('application/octet-stream')
+  })
+
+  it('uses media.aes_key when the item carries no aeskey', async () => {
+    const payload = Buffer.from('silk audio frames')
+    fetchBinary.mockResolvedValue(cdnResponse(aesEcbEncrypt(KEY_BYTES, payload)))
+
+    const result = await downloadIlinkMedia(
+      { media: { encrypt_query_param: 'p', aes_key: Buffer.from(KEY_HEX).toString('base64') } },
+      'voice',
+    )
+    expect(result.data).toEqual(payload)
+    expect(result.mime).toBe('audio/silk')
+  })
+
+  it('falls back to media.aes_key when the item aeskey is unparseable', async () => {
+    const payload = Buffer.from('mp4 atoms')
+    fetchBinary.mockResolvedValue(cdnResponse(aesEcbEncrypt(KEY_BYTES, payload)))
+
+    const result = await downloadIlinkMedia(
+      {
+        media: { encrypt_query_param: 'p', aes_key: Buffer.from(KEY_HEX).toString('base64') },
+        aeskey: 'not-a-key',
+      },
+      'video',
+    )
+    expect(result.data).toEqual(payload)
+  })
+
+  it('downloads a file_item from the host the item names, not the generic CDN', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(aesEcbEncrypt(KEY_BYTES, Buffer.from('doc'))))
+
+    await downloadIlinkMedia(
+      {
+        media: { encrypt_query_param: 'q p' },
+        url: 'https://items.example.com/file',
+        aeskey: KEY_HEX,
+      },
+      'file',
+    )
+    expect(fetchBinary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://items.example.com/file?encrypted_query_param=q%20p',
+      }),
+    )
+  })
+
+  it('rejects a handle with no usable URL before touching the network', async () => {
+    await expect(downloadIlinkMedia({ media: {} }, 'file')).rejects.toThrow(/no download URL/)
+    expect(fetchBinary).not.toHaveBeenCalled()
+  })
+
+  it('passes an abort signal and a wall-clock deadline to the transport', async () => {
+    fetchBinary.mockResolvedValue(cdnResponse(PNG))
+    const signal = new AbortController().signal
+
+    await downloadIlinkMedia({ media: { encrypt_query_param: 'p' } }, 'image', signal)
+    expect(fetchBinary).toHaveBeenCalledWith(
+      expect.objectContaining({ signal, deadlineMs: expect.any(Number) }),
+    )
+  })
+})
+
+describe('uploadIlinkMedia', () => {
+  const baseRequest = {
+    botToken: 'token-abc',
+    toUserId: 'user-1',
+    kind: 'file' as const,
+    data: Buffer.from('0123456789abcdef'),   // exactly one block
+  }
+
+  function mockUploadUrl(): void {
+    fetchJson.mockResolvedValue({ ret: 0, upload_param: 'up param' })
+  }
+
+  it('sends the getuploadurl media_type numbering, which differs from item type', async () => {
+    mockUploadUrl()
+    fetchBinary.mockResolvedValue(cdnResponse(Buffer.alloc(0), 200, {
+      'x-encrypted-param': 'dl-param',
+    }))
+
+    // A video is item type 5 on the wire but media_type 2 here.
+    await uploadIlinkMedia({ ...baseRequest, kind: 'video' })
+    expect(fetchJson.mock.calls[0][3]).toMatchObject({ media_type: 2 })
+
+    fetchJson.mockClear()
+    await uploadIlinkMedia({ ...baseRequest, kind: 'image' })
+    expect(fetchJson.mock.calls[0][3]).toMatchObject({ media_type: 1 })
+
+    fetchJson.mockClear()
+    await uploadIlinkMedia({ ...baseRequest, kind: 'voice' })
+    expect(fetchJson.mock.calls[0][3]).toMatchObject({ media_type: 3 })
+
+    fetchJson.mockClear()
+    await uploadIlinkMedia({ ...baseRequest, kind: 'file' })
+    expect(fetchJson.mock.calls[0][3]).toMatchObject({ media_type: 4 })
+  })
+
+  it('reports the ciphertext size, which always adds a padding block', async () => {
+    mockUploadUrl()
+    fetchBinary.mockResolvedValue(cdnResponse(Buffer.alloc(0), 200, {
+      'x-encrypted-param': 'dl-param',
+    }))
+
+    const aligned = await uploadIlinkMedia(baseRequest)
+    expect(aligned.ciphertextSize).toBe(32)
+    expect(fetchJson.mock.calls[0][3]).toMatchObject({ rawsize: 16, filesize: 32 })
+
+    fetchJson.mockClear()
+    const short = await uploadIlinkMedia({ ...baseRequest, data: Buffer.from('short') })
+    expect(short.ciphertextSize).toBe(16)
+    expect(fetchJson.mock.calls[0][3]).toMatchObject({ rawsize: 5, filesize: 16 })
+  })
+
+  it('takes the download reference from the X-Encrypted-Param header', async () => {
+    mockUploadUrl()
+    fetchBinary.mockResolvedValue(cdnResponse(
+      Buffer.from(JSON.stringify({ encrypt_query_param: 'from-body' })),
+      200,
+      { 'x-encrypted-param': 'from-header' },
+    ))
+
+    const result = await uploadIlinkMedia(baseRequest)
+    expect(result.media.encrypt_query_param).toBe('from-header')
+    expect(result.media.encrypt_type).toBe(1)
+    // The key travels back as base64 of the hex string, per the protocol.
+    expect(Buffer.from(result.media.aes_key!, 'base64').toString()).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('falls back to the body when the header is absent', async () => {
+    mockUploadUrl()
+    fetchBinary.mockResolvedValue(cdnResponse(
+      Buffer.from(JSON.stringify({ encrypt_query_param: 'from-body' })),
+    ))
+
+    const result = await uploadIlinkMedia(baseRequest)
+    expect(result.media.encrypt_query_param).toBe('from-body')
+  })
+
+  it('uploads ciphertext, never the raw bytes', async () => {
+    mockUploadUrl()
+    fetchBinary.mockResolvedValue(cdnResponse(Buffer.alloc(0), 200, {
+      'x-encrypted-param': 'dl-param',
+    }))
+
+    await uploadIlinkMedia(baseRequest)
+    const sent = fetchBinary.mock.calls[0][0] as { url: string; body: Buffer }
+    expect(sent.body).toHaveLength(32)
+    expect(sent.body.equals(baseRequest.data)).toBe(false)
+    expect(sent.url).toContain('encrypted_query_param=up%20param')
+  })
+
+  it('surfaces a non-zero ret from getuploadurl', async () => {
+    fetchJson.mockResolvedValue({ ret: -1, errmsg: 'quota exceeded' })
+
+    await expect(uploadIlinkMedia(baseRequest)).rejects.toThrow(/quota exceeded/)
+    expect(fetchBinary).not.toHaveBeenCalled()
+  })
+
+  it('does not re-send the ciphertext after a 4xx the CDN will repeat', async () => {
+    mockUploadUrl()
+    fetchBinary.mockResolvedValue(cdnResponse(Buffer.alloc(0), 403))
+
+    await expect(uploadIlinkMedia(baseRequest)).rejects.toThrow(/status 403/)
+    expect(fetchBinary).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a 5xx up to the attempt limit', async () => {
+    vi.useFakeTimers()
+    try {
+      mockUploadUrl()
+      fetchBinary.mockResolvedValue(cdnResponse(Buffer.alloc(0), 503))
+
+      const assertion = expect(uploadIlinkMedia(baseRequest)).rejects.toThrow(/status 503/)
+      await vi.advanceTimersByTimeAsync(5_000)
+      await assertion
+      expect(fetchBinary).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries a 200 that carries no download param', async () => {
+    vi.useFakeTimers()
+    try {
+      mockUploadUrl()
+      fetchBinary.mockResolvedValue(cdnResponse(Buffer.from('truncated')))
+
+      const assertion = expect(uploadIlinkMedia(baseRequest))
+        .rejects.toThrow(/no download param/)
+      await vi.advanceTimersByTimeAsync(5_000)
+      await assertion
+      expect(fetchBinary).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('retries a transport failure', async () => {
+    vi.useFakeTimers()
+    try {
+      mockUploadUrl()
+      fetchBinary.mockRejectedValue(new Error('socket hang up'))
+
+      const assertion = expect(uploadIlinkMedia(baseRequest)).rejects.toThrow(/socket hang up/)
+      await vi.advanceTimersByTimeAsync(5_000)
+      await assertion
+      expect(fetchBinary).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects an empty or oversized payload before contacting the API', async () => {
+    await expect(uploadIlinkMedia({ ...baseRequest, data: Buffer.alloc(0) }))
+      .rejects.toThrow(/empty file/)
+    await expect(uploadIlinkMedia({ ...baseRequest, data: Buffer.alloc(26 * 1024 * 1024) }))
+      .rejects.toThrow(/exceeds/)
+    expect(fetchJson).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/apps/runtime/im-channels/media-temp-files.test.ts
+++ b/tests/unit/apps/runtime/im-channels/media-temp-files.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for apps/runtime/im-channels/media-temp-files.
+ *
+ * Covers the two guarantees adapters rely on:
+ *   - a wire-supplied filename cannot escape the staging directory
+ *   - pruning removes only files past the age cutoff, and tolerates a
+ *     missing directory
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { basename, dirname, join } from 'path'
+import {
+  stageMediaFile,
+  pruneMediaTempDir,
+} from '../../../../../src/main/apps/runtime/im-channels/media-temp-files'
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'halo-media-temp-test-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('stageMediaFile', () => {
+  it('writes the payload and returns its path', async () => {
+    const dir = join(root, 'staged')
+    const staged = await stageMediaFile(dir, 'report.pdf', Buffer.from('payload'))
+
+    expect(dirname(staged.localPath)).toBe(dir)
+    expect(readFileSync(staged.localPath).toString()).toBe('payload')
+    expect(staged.filename).toBe('report.pdf')
+  })
+
+  it('keeps a traversal-shaped name inside the staging directory', async () => {
+    const dir = join(root, 'staged')
+    const staged = await stageMediaFile(dir, '../../escape.sh', Buffer.alloc(1))
+
+    expect(staged.filename).toBe('escape.sh')
+    expect(dirname(staged.localPath)).toBe(dir)
+    expect(existsSync(join(root, 'escape.sh'))).toBe(false)
+  })
+
+  it('does not overwrite an earlier file of the same name', async () => {
+    const dir = join(root, 'staged')
+    const first = await stageMediaFile(dir, 'photo.jpg', Buffer.from('one'))
+    const second = await stageMediaFile(dir, 'photo.jpg', Buffer.from('two'))
+
+    expect(second.localPath).not.toBe(first.localPath)
+    expect(readFileSync(first.localPath).toString()).toBe('one')
+    expect(basename(first.localPath).endsWith('photo.jpg')).toBe(true)
+  })
+})
+
+describe('pruneMediaTempDir', () => {
+  it('removes only files older than the cutoff', () => {
+    const dir = join(root, 'staged')
+    mkdirSync(dir, { recursive: true })
+    const stale = join(dir, 'stale.bin')
+    const fresh = join(dir, 'fresh.bin')
+    writeFileSync(stale, 'x')
+    writeFileSync(fresh, 'x')
+    const longAgo = new Date(Date.now() - 48 * 60 * 60 * 1000)
+    utimesSync(stale, longAgo, longAgo)
+
+    expect(pruneMediaTempDir(dir, 24 * 60 * 60 * 1000)).toBe(1)
+    expect(existsSync(stale)).toBe(false)
+    expect(existsSync(fresh)).toBe(true)
+  })
+
+  it('treats a missing directory as nothing to do', () => {
+    expect(pruneMediaTempDir(join(root, 'never-created'), 1000)).toBe(0)
+  })
+})

--- a/tests/unit/apps/runtime/im-channels/weixin-ilink-media.test.ts
+++ b/tests/unit/apps/runtime/im-channels/weixin-ilink-media.test.ts
@@ -1,0 +1,485 @@
+/**
+ * Unit tests for media handling in apps/runtime/im-channels/weixin-ilink.provider.
+ *
+ * Network and crypto are mocked; what is under test is the provider's own
+ * behaviour around them:
+ *   - a media item becomes an attachment (and an inlined image) on the InboundMessage
+ *   - a failing download degrades to a text placeholder without taking down
+ *     the rest of the message or the batch
+ *   - the number of inlined images per message is bounded
+ *   - concurrent downloads are capped, and one chat's messages stay in order
+ *     while other chats proceed in parallel
+ *   - stop() cancels downloads that are still in flight
+ *   - sendFile refuses cleanly when no context_token has been cached yet or the
+ *     file is too large, and builds the right outbound item once it can
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { unlinkSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type {
+  ImChannelInstance,
+  SanctionedFile,
+} from '../../../../../src/shared/types/im-channel'
+import type { InboundMessage } from '../../../../../src/shared/types/inbound-message'
+
+const fetchJson = vi.fn()
+const downloadIlinkMedia = vi.fn()
+const uploadIlinkMedia = vi.fn()
+
+vi.mock('../../../../../src/main/apps/runtime/im-channels/ilink-api', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../../src/main/apps/runtime/im-channels/ilink-api')
+  >()
+  return { ...actual, fetchJson: (...args: unknown[]) => fetchJson(...args) }
+})
+
+vi.mock('../../../../../src/main/apps/runtime/im-channels/ilink-media', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../../src/main/apps/runtime/im-channels/ilink-media')
+  >()
+  return {
+    ...actual,
+    downloadIlinkMedia: (...args: unknown[]) => downloadIlinkMedia(...args),
+    uploadIlinkMedia: (...args: unknown[]) => uploadIlinkMedia(...args),
+  }
+})
+
+const { WeixinIlinkBotProvider } = await import(
+  '../../../../../src/main/apps/runtime/im-channels/weixin-ilink.provider'
+)
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02])
+
+function inboundMessage(
+  itemList: unknown[],
+  messageId = 4242,
+  fromUserId = 'user-1',
+): Record<string, unknown> {
+  return {
+    from_user_id: fromUserId,
+    message_id: messageId,
+    message_type: 1,
+    context_token: 'ctx-1',
+    item_list: itemList,
+  }
+}
+
+/** One getupdates batch, then an abort so the poll loop exits. */
+function servePoll(msgs: unknown[]): void {
+  let served = false
+  fetchJson.mockImplementation(async (_method: string, url: string) => {
+    if (url.endsWith('/ilink/bot/getupdates')) {
+      if (served) throw new Error('Aborted')
+      served = true
+      return { get_updates_buf: 'buf-1', msgs }
+    }
+    return { ret: 0 }
+  })
+}
+
+/** Start an instance and resolve once `count` messages have reached the handler. */
+function startInstanceFor(count: number): {
+  instance: ImChannelInstance
+  delivered: Promise<InboundMessage[]>
+} {
+  const instance = new WeixinIlinkBotProvider().createInstance('inst-1', {
+    botToken: 'token-abc',
+    accountId: 'bot-1',
+  })
+  const seen: InboundMessage[] = []
+  const delivered = new Promise<InboundMessage[]>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`only ${seen.length} of ${count} messages delivered`)),
+      4000,
+    )
+    instance.onInbound((msg) => {
+      seen.push(msg)
+      if (seen.length < count) return
+      clearTimeout(timer)
+      resolve(seen)
+    })
+  })
+  instance.start()
+  return { instance, delivered }
+}
+
+function startInstance(): {
+  instance: ImChannelInstance
+  delivered: Promise<InboundMessage>
+} {
+  const { instance, delivered } = startInstanceFor(1)
+  return { instance, delivered: delivered.then((msgs) => msgs[0]) }
+}
+
+const staged: string[] = []
+
+beforeEach(() => {
+  fetchJson.mockReset()
+  downloadIlinkMedia.mockReset()
+  uploadIlinkMedia.mockReset()
+})
+
+afterEach(() => {
+  for (const path of staged.splice(0)) {
+    try {
+      unlinkSync(path)
+    } catch {
+      /* already gone */
+    }
+  }
+})
+
+describe('inbound media', () => {
+  it('stages an image as an attachment and inlines it for the model', async () => {
+    downloadIlinkMedia.mockResolvedValue({ data: PNG, mime: 'image/png' })
+    servePoll([inboundMessage([
+      { type: 1, text_item: { text: 'look at this' } },
+      { type: 2, image_item: { media: { encrypt_query_param: 'q', aes_key: 'k' } } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    expect(msg.attachments).toHaveLength(1)
+    const attachment = msg.attachments![0]
+    staged.push(attachment.localPath)
+    expect(attachment.type).toBe('image')
+    expect(attachment.mimeType).toBe('image/png')
+    expect(msg.body).toBe(`look at this\n[Image: ${attachment.filename}]`)
+
+    expect(msg.images).toHaveLength(1)
+    expect(msg.images![0].mediaType).toBe('image/png')
+    expect(msg.images![0].data).toBe(PNG.toString('base64'))
+  })
+
+  it('uses the wire file_name for a file item', async () => {
+    downloadIlinkMedia.mockResolvedValue({ data: Buffer.from('%PDF-1.4'), mime: 'application/octet-stream' })
+    servePoll([inboundMessage([
+      { type: 4, file_item: { file_name: 'report.pdf', media: { encrypt_query_param: 'q' } } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    staged.push(msg.attachments![0].localPath)
+    expect(msg.attachments![0].filename).toBe('report.pdf')
+    expect(msg.attachments![0].type).toBe('file')
+    expect(msg.body).toBe('[File: report.pdf]')
+    expect(msg.images).toBeUndefined()
+  })
+
+  it('accepts the alternate wire spelling of the file name', async () => {
+    downloadIlinkMedia.mockResolvedValue({ data: Buffer.from('%PDF-1.4'), mime: 'application/octet-stream' })
+    servePoll([inboundMessage([
+      { type: 4, file_item: { filename: 'legacy.pdf', media: { encrypt_query_param: 'q' } } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    staged.push(msg.attachments![0].localPath)
+    expect(msg.attachments![0].filename).toBe('legacy.pdf')
+    expect(msg.body).toBe('[File: legacy.pdf]')
+  })
+
+  it('attaches an oversized image without inlining it', async () => {
+    const big = Buffer.concat([PNG, Buffer.alloc(3 * 1024 * 1024)])
+    downloadIlinkMedia.mockResolvedValue({ data: big, mime: 'image/png' })
+    servePoll([inboundMessage([
+      { type: 2, image_item: { media: { encrypt_query_param: 'q', aes_key: 'k' } } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    staged.push(msg.attachments![0].localPath)
+    expect(msg.attachments).toHaveLength(1)
+    expect(msg.images).toBeUndefined()
+  })
+
+  it('degrades a failed download to a placeholder and keeps the rest of the message', async () => {
+    downloadIlinkMedia.mockRejectedValue(new Error('PKCS7 unpad failed'))
+    servePoll([inboundMessage([
+      { type: 4, file_item: { file_name: 'report.pdf', media: { encrypt_query_param: 'q' } } },
+      { type: 1, text_item: { text: 'did you get it?' } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    expect(msg.body).toBe('[File: report.pdf — download failed]\ndid you get it?')
+    expect(msg.attachments).toBeUndefined()
+    expect(msg.images).toBeUndefined()
+  })
+
+  it('keeps handling the batch when the inbound handler throws', async () => {
+    servePoll([
+      inboundMessage([{ type: 1, text_item: { text: 'boom' } }], 4242),
+      inboundMessage([{ type: 1, text_item: { text: 'still here' } }], 4243),
+    ])
+
+    const instance = new WeixinIlinkBotProvider().createInstance('inst-1', {
+      botToken: 'token-abc',
+      accountId: 'bot-1',
+    })
+    const seen: string[] = []
+    const delivered = new Promise<InboundMessage>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('no inbound message delivered')), 2000)
+      instance.onInbound((msg) => {
+        seen.push(msg.body)
+        if (msg.body === 'boom') throw new Error('handler exploded')
+        clearTimeout(timer)
+        resolve(msg)
+      })
+    })
+    instance.start()
+
+    const msg = await delivered
+    instance.stop()
+
+    expect(seen).toEqual(['boom', 'still here'])
+    expect(msg.body).toBe('still here')
+  })
+
+  it('cancels an in-flight download when the instance stops', async () => {
+    downloadIlinkMedia.mockResolvedValue({ data: PNG, mime: 'image/png' })
+    servePoll([inboundMessage([
+      { type: 2, image_item: { media: { encrypt_query_param: 'q', aes_key: 'k' } } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    staged.push(msg.attachments![0].localPath)
+
+    const signal = downloadIlinkMedia.mock.calls[0][2] as AbortSignal
+    expect(signal.aborted).toBe(false)
+    instance.stop()
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('bounds how many images one message can inline', async () => {
+    downloadIlinkMedia.mockResolvedValue({ data: PNG, mime: 'image/png' })
+    const imageItem = { type: 2, image_item: { media: { encrypt_query_param: 'q', aes_key: 'k' } } }
+    servePoll([inboundMessage(Array.from({ length: 6 }, () => imageItem))])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    for (const attachment of msg.attachments!) staged.push(attachment.localPath)
+    // Every image is still staged as a file; only the inlining is capped.
+    expect(msg.attachments).toHaveLength(6)
+    expect(msg.images).toHaveLength(4)
+  })
+
+  it('attaches an image it could not type without inlining it', async () => {
+    const bmp = Buffer.concat([Buffer.from('BM'), Buffer.alloc(16, 0x07)])
+    downloadIlinkMedia.mockResolvedValue({ data: bmp, mime: 'application/octet-stream' })
+    servePoll([inboundMessage([
+      { type: 2, image_item: { media: { encrypt_query_param: 'q', aes_key: 'k' } } },
+    ])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    const attachment = msg.attachments![0]
+    staged.push(attachment.localPath)
+    expect(attachment.type).toBe('image')
+    expect(attachment.mimeType).toBe('application/octet-stream')
+    // Not `.octet-stream` — an untypeable image gets a neutral extension.
+    expect(attachment.filename).toMatch(/^image_\d+\.bin$/)
+    expect(msg.images).toBeUndefined()
+  })
+
+  it('reports an unresolved media handle without dropping the item', async () => {
+    servePoll([inboundMessage([{ type: 2 }])])
+
+    const { instance, delivered } = startInstance()
+    const msg = await delivered
+    instance.stop()
+
+    expect(msg.body).toBe('[Image]')
+    expect(downloadIlinkMedia).not.toHaveBeenCalled()
+  })
+})
+
+describe('inbound dispatch', () => {
+  const imageItem = { type: 2, image_item: { media: { encrypt_query_param: 'q', aes_key: 'k' } } }
+
+  /** A download that stays in flight long enough for overlap to be observable. */
+  function slowDownload(onStart: () => void, onEnd: () => void): void {
+    downloadIlinkMedia.mockImplementation(async () => {
+      onStart()
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      onEnd()
+      return { data: PNG, mime: 'image/png' }
+    })
+  }
+
+  it('caps how many downloads a batch can run at once', async () => {
+    let inFlight = 0
+    let peak = 0
+    slowDownload(
+      () => { peak = Math.max(peak, ++inFlight) },
+      () => { inFlight-- },
+    )
+    // One image each, from distinct chats — per-chat ordering imposes no bound here.
+    servePoll(Array.from({ length: 6 }, (_, i) =>
+      inboundMessage([imageItem], 5000 + i, `user-${i}`),
+    ))
+
+    const { instance, delivered } = startInstanceFor(6)
+    const msgs = await delivered
+    instance.stop()
+
+    for (const msg of msgs) staged.push(msg.attachments![0].localPath)
+    expect(peak).toBe(3)
+  })
+
+  it('keeps one chat in order while other chats proceed in parallel', async () => {
+    slowDownload(() => {}, () => {})
+    servePoll([
+      inboundMessage([imageItem], 6001, 'user-1'),
+      inboundMessage([{ type: 1, text_item: { text: 'and this' } }], 6002, 'user-1'),
+      inboundMessage([{ type: 1, text_item: { text: 'unrelated chat' } }], 6003, 'user-2'),
+    ])
+
+    const { instance, delivered } = startInstanceFor(3)
+    const msgs = await delivered
+    instance.stop()
+
+    staged.push(msgs.find((m) => m.attachments)!.attachments![0].localPath)
+    // The other chat is not held up by the download, and user-1's follow-up
+    // still lands behind the image it was sent after.
+    expect(msgs.map((m) => m.chatId)).toEqual(['user-2', 'user-1', 'user-1'])
+    expect(msgs[1].attachments).toHaveLength(1)
+    expect(msgs[2].body).toBe('and this')
+  })
+})
+
+describe('outbound sendFile', () => {
+  const file = {
+    resolvedPath: '/tmp/does-not-exist.pdf',
+    displayName: 'quarterly.pdf',
+  } as unknown as SanctionedFile
+
+  it('refuses without a cached context_token instead of throwing', async () => {
+    fetchJson.mockImplementation(async () => {
+      throw new Error('Aborted')
+    })
+    const instance = new WeixinIlinkBotProvider().createInstance('inst-1', {
+      botToken: 'token-abc',
+      accountId: 'bot-1',
+    })
+
+    await expect(instance.fileCapability!.sendFile('user-1', file, 'direct')).resolves.toBe(false)
+    expect(uploadIlinkMedia).not.toHaveBeenCalled()
+  })
+
+  it('uploads and sends a file item once a context_token has been cached', async () => {
+    downloadIlinkMedia.mockResolvedValue({ data: PNG, mime: 'image/png' })
+    uploadIlinkMedia.mockResolvedValue({
+      media: { encrypt_query_param: 'p', aes_key: 'k', encrypt_type: 1 },
+      ciphertextSize: 32,
+    })
+    servePoll([inboundMessage([{ type: 1, text_item: { text: 'hi' } }])])
+
+    const { instance, delivered } = startInstance()
+    await delivered
+
+    const { writeFile } = await import('fs/promises')
+    const tmpFile = join(tmpdir(), 'halo-ilink-send-test.pdf')
+    await writeFile(tmpFile, 'payload')
+    staged.push(tmpFile)
+
+    const sent = await instance.fileCapability!.sendFile(
+      'user-1',
+      { ...file, resolvedPath: tmpFile } as unknown as SanctionedFile,
+      'direct',
+    )
+    instance.stop()
+    expect(sent).toBe(true)
+
+    const sendCall = fetchJson.mock.calls.find(
+      (call) => typeof call[1] === 'string' && call[1].endsWith('/ilink/bot/sendmessage'),
+    )
+    expect(sendCall).toBeDefined()
+    const body = sendCall![3] as { msg: { context_token: string; item_list: unknown[] } }
+    expect(body.msg.context_token).toBe('ctx-1')
+    expect(body.msg.item_list).toEqual([
+      {
+        type: 4,
+        file_item: {
+          media: { encrypt_query_param: 'p', aes_key: 'k', encrypt_type: 1 },
+          file_name: 'quarterly.pdf',
+          // The raw size — what WeChat shows the recipient as their file's size.
+          file_size: 'payload'.length,
+        },
+      },
+    ])
+    expect(uploadIlinkMedia).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'file', toUserId: 'user-1' }),
+    )
+  })
+
+  it('decides image-vs-file from the name the recipient will see', async () => {
+    uploadIlinkMedia.mockResolvedValue({
+      media: { encrypt_query_param: 'p', aes_key: 'k', encrypt_type: 1 },
+      ciphertextSize: 32,
+    })
+    servePoll([inboundMessage([{ type: 1, text_item: { text: 'hi' } }])])
+
+    const { instance, delivered } = startInstance()
+    await delivered
+
+    const { writeFile } = await import('fs/promises')
+    // Extensionless on disk, but presented to the user as a PNG.
+    const tmpFile = join(tmpdir(), 'halo-ilink-send-test-blob')
+    await writeFile(tmpFile, 'payload')
+    staged.push(tmpFile)
+
+    await instance.fileCapability!.sendFile(
+      'user-1',
+      { resolvedPath: tmpFile, displayName: 'chart.png' } as unknown as SanctionedFile,
+      'direct',
+    )
+    instance.stop()
+
+    expect(uploadIlinkMedia).toHaveBeenCalledWith(expect.objectContaining({ kind: 'image' }))
+    const sendCall = fetchJson.mock.calls.find(
+      (call) => typeof call[1] === 'string' && call[1].endsWith('/ilink/bot/sendmessage'),
+    )
+    const body = sendCall![3] as { msg: { item_list: Array<{ type: number }> } }
+    expect(body.msg.item_list[0].type).toBe(2)
+  })
+
+  it('refuses an oversized file before reading it into memory', async () => {
+    servePoll([inboundMessage([{ type: 1, text_item: { text: 'hi' } }])])
+
+    const { instance, delivered } = startInstance()
+    await delivered
+
+    const { writeFile } = await import('fs/promises')
+    const tmpFile = join(tmpdir(), 'halo-ilink-send-test-big.bin')
+    await writeFile(tmpFile, Buffer.alloc(26 * 1024 * 1024))
+    staged.push(tmpFile)
+
+    const sent = await instance.fileCapability!.sendFile(
+      'user-1',
+      { resolvedPath: tmpFile, displayName: 'big.bin' } as unknown as SanctionedFile,
+      'direct',
+    )
+    instance.stop()
+
+    expect(sent).toBe(false)
+    expect(uploadIlinkMedia).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #264

## 问题

个人微信（iLink）通道收到图片/文件/视频时，只转成 `[Image]` / `[File: unknown]` / `[Video]` 占位文本，agent 知道来了东西却拿不到内容；出站方向没有 `fileCapability`，`send_file_to_chat` 在该通道不可用。企业微信通道早已支持，这里是能力缺口，不是回归。

`[File: unknown]` 另有直接原因：读的是 `file_item.filename`，而协议字段是 `file_item.file_name`。

## 协议

媒体走微信 C2C CDN，密文为 AES-128-ECB + PKCS7：

- 入站：`GET novac2c.cdn.weixin.qq.com/c2c/download?encrypted_query_param=...` 取回密文，用消息内附带的 AES key 本地解密。item 级 `aeskey`（裸 hex）优先于 `media.aes_key`；key 共三种编码（hex 串的 base64 / 16 字节原始的 base64 / 裸 hex），均已支持。图片可能以明文下发，故按魔数命中时走明文快路径 —— 该快路径仅对图片开放，语音/视频/文件的完整性只由 PKCS7 解填充保证。
- 出站：`POST /ilink/bot/getuploadurl` → CDN `POST /c2c/upload` → 读响应头 `x-encrypted-param`（缺失时回落到响应体）→ 作为 `media` 随 `sendmessage` 发出。注意 `getuploadurl` 的 `media_type` 编号（图1/视频2/语音3/文件4）与 `item_list[].type`（文本1/图片2/语音3/文件4/视频5）不是同一套。

## 改动

- 新增 `ilink-media.ts`，端到端持有该协议（密钥解码、下载、解密、加密、上传），provider 只跟本地文件和消息信封打交道，不接触密文与 CDN 参数。
- 新增 `media-temp-files.ts`，通道无关的入站媒体暂存与按时龄清理；企业微信通道改为共用，顺带把它原先未净化的线上文件名纳入 `sanitizeFilename`。
- `weixin-ilink.provider.ts`：入站落盘后填 `InboundMessage.attachments`，可内联的图片再进 `images`；出站实现 `fileCapability`，文本与媒体共用同一条 `sendItems` 通路（-14 与 retcode 判定只存在一份）。
- `ilink-api.ts`：`fetchJson` 重构到新的 `fetchBinary` 之上以承载二进制传输，新增体积上限、空闲超时与独立的挂钟 deadline。长轮询依赖的 AbortSignal 语义与 `'Aborted'` 错误串保持不变。

## 稳定性

入站处理不再阻塞长轮询（下载慢不会拖住 `getupdates`），但因此需要另外两道约束：按 `chatId` 串行以保住单会话内的消息顺序，以及进程级 3 并发上限，避免 `reconnect()` 重放积压时 N × 25MB 同时驻留主进程。单个媒体项解析失败只退化为该项占位文本，不影响同条消息其余内容，也不会打断长轮询。会话过期与重连耗尽会中止在途下载，不留孤儿临时文件。

日志只含尺寸、MIME、encrypt_type 与 key 来源，不含密钥材料、token 或用户媒体字节。

## 已知不确定处

出站 `mid_size` 填密文长度、`file_size` 填明文长度，是目前对协议最合理的解读，需真实账号验证渲染效果。入站 `file_item` 两种拼写都接受。语音仍只取服务端转写文本，不下载音频。

## 验证

- `tsc -p tsconfig.node.json --noEmit`：与改动前基线一致，改动文件零新增错误。
- `npx vitest run tests/unit/apps/runtime/im-channels/`：10 文件 161 用例全绿。新增 3 个测试文件覆盖密钥优先级与三种编码、PKCS7 异常、明文快路径仅限图片、下载 URL 主机选择、上传编号与尺寸公式、`x-encrypted-param` 头/体回落、重试分类、并发上限、跨会话顺序、超限拒读、路径穿越、单项失败降级。

由实施与评审两名成员往返三轮完成，第三轮评审结论 SHIP。请数字人团队复核。