### PR TITLE
fix(compat-router): restore per-conversation session-id header on OpenAI conversion path

### DIFF
--- a/src/main/openai-compat-router/server/codex-responses-handler.ts
+++ b/src/main/openai-compat-router/server/codex-responses-handler.ts
@@ -19,6 +19,7 @@ import { proxyFetch } from '../../services/proxy-fetch'
 import { getEndpointUrlError, isValidEndpointUrl } from './api-type'
 import { applyProviderAdapter, type AdapterContext } from './provider-adapters'
 import { deferInputTokensEstimate, fillResponseUsageFallback } from '../utils/usage-estimator'
+import { pickSessionAffinityHeaders } from '../utils'
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 
@@ -618,9 +619,9 @@ export async function handleResponsesRequest(
   codexRequest: CodexResponsesRequest,
   config: BackendConfig,
   res: ExpressResponse,
-  options: { debug?: boolean; timeoutMs?: number } = {}
+  options: { debug?: boolean; timeoutMs?: number; sdkHeaders?: Record<string, string> } = {}
 ): Promise<void> {
-  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS } = options
+  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS, sdkHeaders } = options
   const { url: backendUrl, key: apiKey, headers: customHeaders, apiType: configApiType, adapterId } = config
 
   if (!isValidEndpointUrl(backendUrl)) {
@@ -734,7 +735,13 @@ export async function handleResponsesRequest(
     ? convertAnthropicToOpenAIResponses(requestToSend, convertOptions).request
     : convertAnthropicToOpenAIChat(requestToSend, convertOptions).request
 
-  const requestHeaders: Record<string, string> = { ...(customHeaders || {}) }
+  // Restore the per-conversation session-id header (Codex sends Session_id) so
+  // upstream channel-affinity routing can pin the conversation. The conversion
+  // rebuilds headers from config only, so it must be re-added explicitly.
+  const requestHeaders: Record<string, string> = {
+    ...(customHeaders || {}),
+    ...pickSessionAffinityHeaders(sdkHeaders),
+  }
   const adapterContext: AdapterContext = { originalRequest: requestToSend }
   applyProviderAdapter(backendUrl, openaiRequest as Record<string, unknown>, requestHeaders, adapterId, adapterContext)
 

--- a/src/main/openai-compat-router/server/request-handler.ts
+++ b/src/main/openai-compat-router/server/request-handler.ts
@@ -25,7 +25,7 @@ import {
   streamAnthropicPassthrough,
   pipeAnthropicPassthrough
 } from '../stream'
-import { isNativeAnthropicHost, normalizeSystemPrompt } from '../utils'
+import { isNativeAnthropicHost, normalizeSystemPrompt, pickSessionAffinityHeaders } from '../utils'
 import { proxyFetch } from '../../services/proxy-fetch'
 import { getApiTypeFromUrl, isValidEndpointUrl, getEndpointUrlError, shouldForceStream } from './api-type'
 import { runInterceptors } from '../interceptors'
@@ -491,7 +491,7 @@ async function handleOpenAIConversion(
   res: ExpressResponse,
   options: RequestHandlerOptions
 ): Promise<void> {
-  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS } = options
+  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS, sdkHeaders } = options
   const { url: backendUrl, key: apiKey, model, headers: customHeaders, apiType: configApiType, adapterId } = config
   console.log(`[RequestHandler] adapterId: ${adapterId || 'none'}`)
 
@@ -539,8 +539,14 @@ async function handleOpenAIConversion(
     console.log(`[RequestHandler] wire=${apiType} tools=${toolCount}`)
     console.log(`[RequestHandler] POST ${backendUrl} (stream=${wantStream ?? false})`)
 
-    // Build headers: start with custom headers from config
-    const requestHeaders: Record<string, string> = { ...(customHeaders || {}) }
+    // Build headers: start with custom headers from config, then restore the
+    // per-conversation session-id header so upstream channel-affinity routing
+    // can pin the conversation. The conversion path rebuilds headers from
+    // scratch, so without this the SDK's session id never reaches upstream.
+    const requestHeaders: Record<string, string> = {
+      ...(customHeaders || {}),
+      ...pickSessionAffinityHeaders(sdkHeaders),
+    }
 
     // Apply provider-specific transformations (e.g., Groq temperature fix, OpenRouter headers)
     const adapterContext: AdapterContext = { originalRequest: requestToSend }

--- a/src/main/openai-compat-router/server/router.ts
+++ b/src/main/openai-compat-router/server/router.ts
@@ -119,7 +119,17 @@ export function createApp(options: RouterOptions = {}): Express {
 
     console.log(`[Router] in_detail endpoint=/v1/responses method=${req.method} url=${req.url} from=${req.ip || ''}:${req.socket?.remotePort ?? ''} backend_host=${(() => { try { return new URL(decodedConfig.url).host } catch { return decodedConfig.url } })()} model_override=${decodedConfig.model || ''} api_type=${decodedConfig.apiType || ''} ts=${Date.now()}`)
 
-    await handleResponsesRequest(req.body || {}, decodedConfig, res, { debug, timeoutMs })
+    // Collect SDK headers so the handler can restore session-affinity headers
+    // (Codex sends the session id as Session_id) onto the upstream request.
+    const HOP_BY_HOP = new Set(['host', 'connection', 'content-length', 'transfer-encoding', 'authorization'])
+    const sdkHeaders: Record<string, string> = {}
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!HOP_BY_HOP.has(key) && value) {
+        sdkHeaders[key] = Array.isArray(value) ? value[0] : value
+      }
+    }
+
+    await handleResponsesRequest(req.body || {}, decodedConfig, res, { debug, timeoutMs, sdkHeaders })
   })
 
   // Token counting endpoint

--- a/src/main/openai-compat-router/utils/index.ts
+++ b/src/main/openai-compat-router/utils/index.ts
@@ -6,6 +6,7 @@ export * from './id'
 export * from './config'
 export * from './url'
 export * from './normalize-system-prompt'
+export * from './session-affinity'
 
 /**
  * Safe JSON parse with fallback

--- a/src/main/openai-compat-router/utils/session-affinity.ts
+++ b/src/main/openai-compat-router/utils/session-affinity.ts
@@ -1,0 +1,36 @@
+/**
+ * Session-affinity headers carry the per-conversation session id that upstream
+ * channel-affinity routing (halo cloud gateway) uses to pin a conversation to a
+ * stable channel+key, keeping the prompt cache warm. The two SDKs name it
+ * differently:
+ *   - Claude Code SDK: x-claude-code-session-id
+ *   - Codex SDK:        session_id  (mirrors the request body's prompt_cache_key)
+ *
+ * The OpenAI-conversion path (chat_completions / responses) rebuilds a minimal
+ * header set from provider config only, so without this allowlist these headers
+ * never reach upstream and affinity silently degrades to per-request routing.
+ * The anthropic_passthrough path forwards all SDK headers already and does not
+ * need this.
+ *
+ * Allowlist — not passthrough — so the conversion path stays closed by default:
+ * only these two header names cross over, nothing else from the SDK request.
+ */
+const SESSION_AFFINITY_HEADERS = new Set(['x-claude-code-session-id', 'session_id'])
+
+/**
+ * Extract the session-affinity headers from an SDK header map (Express lowercases
+ * incoming header names). Returns canonical lowercase keys; upstream and the
+ * gateway read them case-insensitively.
+ */
+export function pickSessionAffinityHeaders(
+  sdkHeaders?: Record<string, string>
+): Record<string, string> {
+  if (!sdkHeaders) return {}
+  const picked: Record<string, string> = {}
+  for (const [key, value] of Object.entries(sdkHeaders)) {
+    if (value && SESSION_AFFINITY_HEADERS.has(key.toLowerCase())) {
+      picked[key.toLowerCase()] = value
+    }
+  }
+  return picked
+}

--- a/tests/unit/openai-compat-router/request-handler.test.ts
+++ b/tests/unit/openai-compat-router/request-handler.test.ts
@@ -71,10 +71,14 @@ vi.mock('../../../src/main/openai-compat-router/server/api-type', () => ({
 
 const isNativeAnthropicHost = vi.fn(() => false)
 const normalizeSystemPrompt = vi.fn((request: unknown) => ({ request, modified: false }))
-vi.mock('../../../src/main/openai-compat-router/utils', () => ({
-  isNativeAnthropicHost: (...a: unknown[]) => isNativeAnthropicHost(...a),
-  normalizeSystemPrompt: (...a: unknown[]) => normalizeSystemPrompt(...a),
-}))
+vi.mock('../../../src/main/openai-compat-router/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/openai-compat-router/utils')>()
+  return {
+    ...actual,
+    isNativeAnthropicHost: (...a: unknown[]) => isNativeAnthropicHost(...a),
+    normalizeSystemPrompt: (...a: unknown[]) => normalizeSystemPrompt(...a),
+  }
+})
 
 vi.mock('../../../src/main/openai-compat-router/utils/token-counter', () => ({
   countTokens: vi.fn(() => 7),

--- a/tests/unit/openai-compat-router/session-affinity.test.ts
+++ b/tests/unit/openai-compat-router/session-affinity.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression: the per-conversation session-id header must survive to the
+ * upstream request on the OpenAI-conversion path (chat_completions / responses),
+ * not only on the anthropic_passthrough path.
+ *
+ * Upstream channel-affinity routing (halo cloud gateway) keys on this header to
+ * pin a conversation to a stable channel+key. The conversion path rebuilds a
+ * minimal header set from provider config, which historically dropped it — this
+ * test locks in that it is restored via pickSessionAffinityHeaders.
+ *
+ * The mock upstream stands in for halo cloud: we assert on the exact header map
+ * handed to proxyFetch, i.e. what physically reaches upstream.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Response as ExpressResponse } from 'express'
+import { pickSessionAffinityHeaders } from '../../../src/main/openai-compat-router/utils/session-affinity'
+
+const runInterceptors = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/interceptors', () => ({
+  runInterceptors: (...a: unknown[]) => runInterceptors(...a),
+}))
+
+const handleKiroRequest = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/adapters/kiro.adapter', () => ({
+  handleKiroRequest: (...a: unknown[]) => handleKiroRequest(...a),
+}))
+
+const convertAnthropicToOpenAIChat = vi.fn()
+const convertAnthropicToOpenAIResponses = vi.fn()
+const convertOpenAIChatToAnthropic = vi.fn()
+const convertOpenAIResponsesToAnthropic = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/converters', () => ({
+  convertAnthropicToOpenAIChat: (...a: unknown[]) => convertAnthropicToOpenAIChat(...a),
+  convertAnthropicToOpenAIResponses: (...a: unknown[]) => convertAnthropicToOpenAIResponses(...a),
+  convertOpenAIChatToAnthropic: (...a: unknown[]) => convertOpenAIChatToAnthropic(...a),
+  convertOpenAIResponsesToAnthropic: (...a: unknown[]) => convertOpenAIResponsesToAnthropic(...a),
+}))
+
+const streamOpenAIChatToAnthropic = vi.fn()
+const streamOpenAIResponsesToAnthropic = vi.fn()
+const streamAnthropicPassthrough = vi.fn()
+const pipeAnthropicPassthrough = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/stream', () => ({
+  streamOpenAIChatToAnthropic: (...a: unknown[]) => streamOpenAIChatToAnthropic(...a),
+  streamOpenAIResponsesToAnthropic: (...a: unknown[]) => streamOpenAIResponsesToAnthropic(...a),
+  streamAnthropicPassthrough: (...a: unknown[]) => streamAnthropicPassthrough(...a),
+  pipeAnthropicPassthrough: (...a: unknown[]) => pipeAnthropicPassthrough(...a),
+}))
+
+const proxyFetch = vi.fn()
+vi.mock('../../../src/main/services/proxy-fetch', () => ({
+  proxyFetch: (...a: unknown[]) => proxyFetch(...a),
+}))
+
+const applyProviderAdapter = vi.fn(() => null)
+vi.mock('../../../src/main/openai-compat-router/server/provider-adapters', () => ({
+  applyProviderAdapter: (...a: unknown[]) => applyProviderAdapter(...a),
+}))
+
+const getApiTypeFromUrl = vi.fn(() => 'chat_completions')
+const isValidEndpointUrl = vi.fn(() => true)
+const getEndpointUrlError = vi.fn(() => 'bad url')
+const shouldForceStream = vi.fn(() => false)
+vi.mock('../../../src/main/openai-compat-router/server/api-type', () => ({
+  getApiTypeFromUrl: (...a: unknown[]) => getApiTypeFromUrl(...a),
+  isValidEndpointUrl: (...a: unknown[]) => isValidEndpointUrl(...a),
+  getEndpointUrlError: (...a: unknown[]) => getEndpointUrlError(...a),
+  shouldForceStream: (...a: unknown[]) => shouldForceStream(...a),
+}))
+
+// Keep the real pickSessionAffinityHeaders — the drop/restore behavior under
+// test lives there — while stubbing the other utils used by the handler.
+const isNativeAnthropicHost = vi.fn(() => false)
+const normalizeSystemPrompt = vi.fn((request: unknown) => ({ request, modified: false }))
+vi.mock('../../../src/main/openai-compat-router/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/openai-compat-router/utils')>()
+  return {
+    ...actual,
+    isNativeAnthropicHost: (...a: unknown[]) => isNativeAnthropicHost(...a),
+    normalizeSystemPrompt: (...a: unknown[]) => normalizeSystemPrompt(...a),
+  }
+})
+
+vi.mock('../../../src/main/openai-compat-router/utils/token-counter', () => ({
+  countTokens: vi.fn(() => 7),
+}))
+
+vi.mock('../../../src/main/openai-compat-router/utils/usage-estimator', () => ({
+  deferInputTokensEstimate: vi.fn(() => async () => 0),
+  fillResponseUsageFallback: vi.fn(),
+}))
+
+import { handleMessagesRequest } from '../../../src/main/openai-compat-router/server/request-handler'
+
+function makeRes() {
+  const listeners: Record<string, Array<() => void>> = {}
+  return {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    jsonBody: undefined as unknown,
+    ended: undefined as string | undefined,
+    status(n: number) { this.statusCode = n; return this },
+    setHeader(k: string, v: string) { this.headers[k.toLowerCase()] = v },
+    getHeader(k: string) { return this.headers[k.toLowerCase()] },
+    json(b: unknown) { this.jsonBody = b },
+    end(b?: string) { this.ended = b },
+    on(event: string, cb: () => void) { (listeners[event] ??= []).push(cb) },
+    emit(event: string) { for (const cb of listeners[event] ?? []) cb() },
+  }
+}
+
+function fakeResponse(opts: { ok?: boolean; status?: number; json?: unknown }): globalThis.Response {
+  const h = new Map<string, string>()
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    headers: {
+      forEach: (cb: (v: string, k: string) => void) => h.forEach((v, k) => cb(v, k)),
+      get: (k: string) => h.get(k.toLowerCase()) ?? null,
+    },
+    text: async () => '',
+    json: async () => opts.json ?? {},
+    body: null,
+  } as unknown as globalThis.Response
+}
+
+function baseConfig(over: Record<string, unknown> = {}) {
+  return { url: 'https://halo-cloud.example/v1/llm/chat/completions', key: 'sk-test', ...over } as never
+}
+
+function anthReq(over: Record<string, unknown> = {}) {
+  return {
+    model: 'public',
+    max_tokens: 16,
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: false,
+    ...over,
+  } as never
+}
+
+const CLAUDE_SESSION_HEADER = 'x-claude-code-session-id'
+const CLAUDE_SESSION_VALUE = '58b1790b-0000-4000-8000-000000000001'
+
+function loweredHeaders(call: unknown): Record<string, string> {
+  const outgoing = (call as { headers: Record<string, string> }).headers
+  return Object.fromEntries(
+    Object.entries(outgoing).map(([k, v]) => [k.toLowerCase(), v]),
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  runInterceptors.mockResolvedValue({ intercepted: false, request: anthReq() })
+  normalizeSystemPrompt.mockImplementation((request: unknown) => ({ request, modified: false }))
+  isValidEndpointUrl.mockReturnValue(true)
+  getApiTypeFromUrl.mockReturnValue('chat_completions')
+  shouldForceStream.mockReturnValue(false)
+  isNativeAnthropicHost.mockReturnValue(false)
+  applyProviderAdapter.mockReturnValue(null)
+  convertAnthropicToOpenAIChat.mockReturnValue({ request: { model: 'public', messages: [] } })
+  convertOpenAIChatToAnthropic.mockReturnValue({ type: 'message', content: [] })
+})
+
+describe('pickSessionAffinityHeaders', () => {
+  it('extracts the Claude session header (case-insensitive)', () => {
+    expect(pickSessionAffinityHeaders({ 'X-Claude-Code-Session-Id': 'abc' }))
+      .toEqual({ 'x-claude-code-session-id': 'abc' })
+  })
+
+  it('extracts the Codex session header', () => {
+    expect(pickSessionAffinityHeaders({ Session_id: 'xyz' }))
+      .toEqual({ session_id: 'xyz' })
+  })
+
+  it('drops everything not on the allowlist', () => {
+    expect(pickSessionAffinityHeaders({
+      'x-claude-code-session-id': 'abc',
+      authorization: 'Bearer leak',
+      'anthropic-beta': 'oauth',
+    })).toEqual({ 'x-claude-code-session-id': 'abc' })
+  })
+
+  it('is undefined- and empty-safe', () => {
+    expect(pickSessionAffinityHeaders(undefined)).toEqual({})
+    expect(pickSessionAffinityHeaders({ 'x-claude-code-session-id': '' })).toEqual({})
+  })
+})
+
+describe('session-id header on the halo cloud path (chat_completions conversion)', () => {
+  it('conversion path FORWARDS x-claude-code-session-id to upstream', async () => {
+    const req = anthReq()
+    runInterceptors.mockResolvedValue({ intercepted: false, request: req })
+    proxyFetch.mockResolvedValue(fakeResponse({ ok: true, json: { id: 'x' } }))
+    const res = makeRes()
+
+    await handleMessagesRequest(
+      req,
+      baseConfig({ apiType: 'chat_completions' }),
+      res as unknown as ExpressResponse,
+      { sdkHeaders: { [CLAUDE_SESSION_HEADER]: CLAUDE_SESSION_VALUE } },
+    )
+
+    const lowered = loweredHeaders(proxyFetch.mock.calls[0][1])
+    expect(lowered[CLAUDE_SESSION_HEADER]).toBe(CLAUDE_SESSION_VALUE)
+  })
+
+  it('passthrough path also forwards x-claude-code-session-id to upstream', async () => {
+    const req = anthReq()
+    runInterceptors.mockResolvedValue({ intercepted: false, request: req })
+    proxyFetch.mockResolvedValue(fakeResponse({ ok: true }))
+    const res = makeRes()
+
+    await handleMessagesRequest(
+      req,
+      baseConfig({ apiType: 'anthropic_passthrough', url: 'https://third-party/v1/messages' }),
+      res as unknown as ExpressResponse,
+      { sdkHeaders: { [CLAUDE_SESSION_HEADER]: CLAUDE_SESSION_VALUE } },
+    )
+
+    const lowered = loweredHeaders(proxyFetch.mock.calls[0][1])
+    expect(lowered[CLAUDE_SESSION_HEADER]).toBe(CLAUDE_SESSION_VALUE)
+  })
+})


### PR DESCRIPTION
## Related Issue
<!-- Link the issue this MR addresses -->
Fixes #

## Changes
<!-- What changed and why -->
The `chat_completions` / `responses` conversion paths in the openai-compat-router rebuild the upstream request headers from config and dropped the SDK's per-conversation session-id header. That header is what the gateway's channel-affinity rules key on to pin a conversation to a stable upstream channel+key (keeping the prompt cache warm). Without it, every turn could land on a different channel/key.

This restores a narrow allowlist of session headers on the conversion path:
- `x-claude-code-session-id` — Claude Code SDK
- `session_id` — Codex SDK (`Session_id`, lowercased by the client)

Implementation:
- New pure helper `utils/session-affinity.ts` → `pickSessionAffinityHeaders(sdkHeaders)` (allowlist only, no other headers).
- `request-handler.ts` (chat conversion) and `codex-responses-handler.ts` (responses conversion) merge those headers on top of the config headers.
- The anthropic passthrough path already forwarded all headers, so it is unchanged.

Verified end-to-end against a header-logging upstream stand-in: the session id was `<MISSING>` before the fix and present after, on both the Claude Code (`x-claude-code-session-id`) and Codex (`session_id`) conversion paths.

> Note: This change was AI-assisted (Halo). The author is not a core maintainer of this repo.

## Dev Checklist
- [x] Verified locally with `npm run dev`
- [ ] Ran `/code-review` and addressed valid findings
- [ ] Ran `/comment-review` to clean up comments
- [x] Committed via `/code-commit` (no manual `git add .`)
- [x] Ran `test:unit`
- [ ] Ran `test:e2e:smoke` (recommended for large changes)

## Red Lines (common reasons for rejection)
- [x] Code and comments are in English only
- [x] All UI text uses `t('English text')`, no hardcoded strings
- [x] No unrelated changes, temporary code, or debug statements

## Screenshots (required for UI changes)
No UI changes.

---
> ℹ️ After submission, an automated Halo AI review team will review this MR and leave comments. Please watch for and address their feedback.