### PR TITLE
fix(compat-router): restore per-conversation session-id header on OpenAI conversion path

### DIFF
--- a/src/main/openai-compat-router/server/codex-responses-handler.ts
+++ b/src/main/openai-compat-router/server/codex-responses-handler.ts
@@ -19,6 +19,7 @@ import { proxyFetch } from '../../services/proxy-fetch'
 import { getEndpointUrlError, isValidEndpointUrl } from './api-type'
 import { applyProviderAdapter, type AdapterContext } from './provider-adapters'
 import { deferInputTokensEstimate, fillResponseUsageFallback } from '../utils/usage-estimator'
+import { pickSessionAffinityHeaders } from '../utils'
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 
@@ -618,9 +619,9 @@ export async function handleResponsesRequest(
   codexRequest: CodexResponsesRequest,
   config: BackendConfig,
   res: ExpressResponse,
-  options: { debug?: boolean; timeoutMs?: number } = {}
+  options: { debug?: boolean; timeoutMs?: number; sdkHeaders?: Record<string, string> } = {}
 ): Promise<void> {
-  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS } = options
+  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS, sdkHeaders } = options
   const { url: backendUrl, key: apiKey, headers: customHeaders, apiType: configApiType, adapterId } = config
 
   if (!isValidEndpointUrl(backendUrl)) {
@@ -734,7 +735,10 @@ export async function handleResponsesRequest(
     ? convertAnthropicToOpenAIResponses(requestToSend, convertOptions).request
     : convertAnthropicToOpenAIChat(requestToSend, convertOptions).request
 
-  const requestHeaders: Record<string, string> = { ...(customHeaders || {}) }
+  const requestHeaders: Record<string, string> = {
+    ...(customHeaders || {}),
+    ...pickSessionAffinityHeaders(sdkHeaders),
+  }
   const adapterContext: AdapterContext = { originalRequest: requestToSend }
   applyProviderAdapter(backendUrl, openaiRequest as Record<string, unknown>, requestHeaders, adapterId, adapterContext)
 

--- a/src/main/openai-compat-router/server/request-handler.ts
+++ b/src/main/openai-compat-router/server/request-handler.ts
@@ -25,7 +25,7 @@ import {
   streamAnthropicPassthrough,
   pipeAnthropicPassthrough
 } from '../stream'
-import { isNativeAnthropicHost, normalizeSystemPrompt, safeJsonParse } from '../utils'
+import { isNativeAnthropicHost, normalizeSystemPrompt, safeJsonParse, pickSessionAffinityHeaders } from '../utils'
 import { proxyFetch } from '../../services/proxy-fetch'
 import { getApiTypeFromUrl, isValidEndpointUrl, getEndpointUrlError, shouldForceStream } from './api-type'
 import { runInterceptors } from '../interceptors'
@@ -515,7 +515,7 @@ async function handleOpenAIConversion(
   res: ExpressResponse,
   options: RequestHandlerOptions
 ): Promise<void> {
-  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS } = options
+  const { debug = false, timeoutMs = DEFAULT_TIMEOUT_MS, sdkHeaders } = options
   const { url: backendUrl, key: apiKey, model, headers: customHeaders, apiType: configApiType, adapterId } = config
   console.log(`[RequestHandler] adapterId: ${adapterId || 'none'}`)
 
@@ -563,8 +563,10 @@ async function handleOpenAIConversion(
     console.log(`[RequestHandler] wire=${apiType} tools=${toolCount}`)
     console.log(`[RequestHandler] POST ${backendUrl} (stream=${wantStream ?? false})`)
 
-    // Build headers: start with custom headers from config
-    const requestHeaders: Record<string, string> = { ...(customHeaders || {}) }
+    const requestHeaders: Record<string, string> = {
+      ...(customHeaders || {}),
+      ...pickSessionAffinityHeaders(sdkHeaders),
+    }
 
     // Apply provider-specific transformations (e.g., Groq temperature fix, OpenRouter headers)
     const adapterContext: AdapterContext = { originalRequest: requestToSend }

--- a/src/main/openai-compat-router/server/router.ts
+++ b/src/main/openai-compat-router/server/router.ts
@@ -119,7 +119,17 @@ export function createApp(options: RouterOptions = {}): Express {
 
     console.log(`[Router] in_detail endpoint=/v1/responses method=${req.method} url=${req.url} from=${req.ip || ''}:${req.socket?.remotePort ?? ''} backend_host=${(() => { try { return new URL(decodedConfig.url).host } catch { return decodedConfig.url } })()} model_override=${decodedConfig.model || ''} api_type=${decodedConfig.apiType || ''} ts=${Date.now()}`)
 
-    await handleResponsesRequest(req.body || {}, decodedConfig, res, { debug, timeoutMs })
+    // Collect SDK headers so the handler can restore session-affinity headers
+    // onto the upstream request.
+    const HOP_BY_HOP = new Set(['host', 'connection', 'content-length', 'transfer-encoding', 'authorization'])
+    const sdkHeaders: Record<string, string> = {}
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!HOP_BY_HOP.has(key) && value) {
+        sdkHeaders[key] = Array.isArray(value) ? value[0] : value
+      }
+    }
+
+    await handleResponsesRequest(req.body || {}, decodedConfig, res, { debug, timeoutMs, sdkHeaders })
   })
 
   // Token counting endpoint

--- a/src/main/openai-compat-router/utils/index.ts
+++ b/src/main/openai-compat-router/utils/index.ts
@@ -6,6 +6,7 @@ export * from './id'
 export * from './config'
 export * from './url'
 export * from './normalize-system-prompt'
+export * from './session-affinity'
 
 /**
  * Safe JSON parse with fallback

--- a/src/main/openai-compat-router/utils/session-affinity.ts
+++ b/src/main/openai-compat-router/utils/session-affinity.ts
@@ -1,0 +1,34 @@
+/**
+ * Session-affinity headers carry the per-conversation session id that upstream
+ * channel-affinity routing (halo cloud gateway) uses to pin a conversation to a
+ * stable channel+key, keeping the prompt cache warm. The two SDKs name it
+ * differently:
+ *   - Claude Code SDK: x-claude-code-session-id
+ *   - Codex SDK:        session_id  (mirrors the request body's prompt_cache_key)
+ *
+ * The OpenAI-conversion path (chat_completions / responses) rebuilds a minimal
+ * header set from provider config only, so without this these headers never
+ * reach upstream and affinity silently degrades to per-request routing. The
+ * anthropic_passthrough path forwards all SDK headers already and does not need
+ * this. An allowlist (not passthrough) keeps the conversion path closed by
+ * default so nothing else from the SDK request leaks to a foreign upstream.
+ */
+const SESSION_AFFINITY_HEADERS = new Set(['x-claude-code-session-id', 'session_id'])
+
+/**
+ * Extract the session-affinity headers from an SDK header map (Express lowercases
+ * incoming header names). Returns canonical lowercase keys; upstream and the
+ * gateway read them case-insensitively.
+ */
+export function pickSessionAffinityHeaders(
+  sdkHeaders?: Record<string, string>
+): Record<string, string> {
+  if (!sdkHeaders) return {}
+  const picked: Record<string, string> = {}
+  for (const [key, value] of Object.entries(sdkHeaders)) {
+    if (value && SESSION_AFFINITY_HEADERS.has(key.toLowerCase())) {
+      picked[key.toLowerCase()] = value
+    }
+  }
+  return picked
+}

--- a/tests/unit/openai-compat-router/request-handler.test.ts
+++ b/tests/unit/openai-compat-router/request-handler.test.ts
@@ -71,17 +71,14 @@ vi.mock('../../../src/main/openai-compat-router/server/api-type', () => ({
 
 const isNativeAnthropicHost = vi.fn(() => false)
 const normalizeSystemPrompt = vi.fn((request: unknown) => ({ request, modified: false }))
-vi.mock('../../../src/main/openai-compat-router/utils', () => ({
-  isNativeAnthropicHost: (...a: unknown[]) => isNativeAnthropicHost(...a),
-  normalizeSystemPrompt: (...a: unknown[]) => normalizeSystemPrompt(...a),
-  safeJsonParse: (input: string) => {
-    try {
-      return JSON.parse(input)
-    } catch {
-      return null
-    }
-  },
-}))
+vi.mock('../../../src/main/openai-compat-router/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/openai-compat-router/utils')>()
+  return {
+    ...actual,
+    isNativeAnthropicHost: (...a: unknown[]) => isNativeAnthropicHost(...a),
+    normalizeSystemPrompt: (...a: unknown[]) => normalizeSystemPrompt(...a),
+  }
+})
 
 vi.mock('../../../src/main/openai-compat-router/utils/token-counter', () => ({
   countTokens: vi.fn(() => 7),

--- a/tests/unit/openai-compat-router/session-affinity.test.ts
+++ b/tests/unit/openai-compat-router/session-affinity.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Regression: the per-conversation session-id header must survive to the
+ * upstream request on the OpenAI-conversion path (chat_completions / responses),
+ * not only on the anthropic_passthrough path.
+ *
+ * Upstream channel-affinity routing (halo cloud gateway) keys on this header to
+ * pin a conversation to a stable channel+key. The conversion path rebuilds a
+ * minimal header set from provider config, which historically dropped it — this
+ * test locks in that it is restored via pickSessionAffinityHeaders.
+ *
+ * The mock upstream stands in for halo cloud: we assert on the exact header map
+ * handed to proxyFetch, i.e. what physically reaches upstream.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Response as ExpressResponse } from 'express'
+import { pickSessionAffinityHeaders } from '../../../src/main/openai-compat-router/utils/session-affinity'
+
+const runInterceptors = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/interceptors', () => ({
+  runInterceptors: (...a: unknown[]) => runInterceptors(...a),
+}))
+
+const handleKiroRequest = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/adapters/kiro.adapter', () => ({
+  handleKiroRequest: (...a: unknown[]) => handleKiroRequest(...a),
+}))
+
+const convertAnthropicToOpenAIChat = vi.fn()
+const convertAnthropicToOpenAIResponses = vi.fn()
+const convertOpenAIChatToAnthropic = vi.fn()
+const convertOpenAIResponsesToAnthropic = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/converters', () => ({
+  convertAnthropicToOpenAIChat: (...a: unknown[]) => convertAnthropicToOpenAIChat(...a),
+  convertAnthropicToOpenAIResponses: (...a: unknown[]) => convertAnthropicToOpenAIResponses(...a),
+  convertOpenAIChatToAnthropic: (...a: unknown[]) => convertOpenAIChatToAnthropic(...a),
+  convertOpenAIResponsesToAnthropic: (...a: unknown[]) => convertOpenAIResponsesToAnthropic(...a),
+}))
+
+const streamOpenAIChatToAnthropic = vi.fn()
+const streamOpenAIResponsesToAnthropic = vi.fn()
+const streamAnthropicPassthrough = vi.fn()
+const pipeAnthropicPassthrough = vi.fn()
+vi.mock('../../../src/main/openai-compat-router/stream', () => ({
+  streamOpenAIChatToAnthropic: (...a: unknown[]) => streamOpenAIChatToAnthropic(...a),
+  streamOpenAIResponsesToAnthropic: (...a: unknown[]) => streamOpenAIResponsesToAnthropic(...a),
+  streamAnthropicPassthrough: (...a: unknown[]) => streamAnthropicPassthrough(...a),
+  pipeAnthropicPassthrough: (...a: unknown[]) => pipeAnthropicPassthrough(...a),
+}))
+
+const proxyFetch = vi.fn()
+vi.mock('../../../src/main/services/proxy-fetch', () => ({
+  proxyFetch: (...a: unknown[]) => proxyFetch(...a),
+}))
+
+const applyProviderAdapter = vi.fn(() => null)
+vi.mock('../../../src/main/openai-compat-router/server/provider-adapters', () => ({
+  applyProviderAdapter: (...a: unknown[]) => applyProviderAdapter(...a),
+}))
+
+const getApiTypeFromUrl = vi.fn(() => 'chat_completions')
+const isValidEndpointUrl = vi.fn(() => true)
+const getEndpointUrlError = vi.fn(() => 'bad url')
+const shouldForceStream = vi.fn(() => false)
+vi.mock('../../../src/main/openai-compat-router/server/api-type', () => ({
+  getApiTypeFromUrl: (...a: unknown[]) => getApiTypeFromUrl(...a),
+  isValidEndpointUrl: (...a: unknown[]) => isValidEndpointUrl(...a),
+  getEndpointUrlError: (...a: unknown[]) => getEndpointUrlError(...a),
+  shouldForceStream: (...a: unknown[]) => shouldForceStream(...a),
+}))
+
+// Keep the real pickSessionAffinityHeaders — the drop/restore behavior under
+// test lives there — while stubbing the other utils used by the handler.
+const isNativeAnthropicHost = vi.fn(() => false)
+const normalizeSystemPrompt = vi.fn((request: unknown) => ({ request, modified: false }))
+vi.mock('../../../src/main/openai-compat-router/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/main/openai-compat-router/utils')>()
+  return {
+    ...actual,
+    isNativeAnthropicHost: (...a: unknown[]) => isNativeAnthropicHost(...a),
+    normalizeSystemPrompt: (...a: unknown[]) => normalizeSystemPrompt(...a),
+  }
+})
+
+vi.mock('../../../src/main/openai-compat-router/utils/token-counter', () => ({
+  countTokens: vi.fn(() => 7),
+}))
+
+vi.mock('../../../src/main/openai-compat-router/utils/usage-estimator', () => ({
+  deferInputTokensEstimate: vi.fn(() => async () => 0),
+  fillResponseUsageFallback: vi.fn(),
+}))
+
+import { handleMessagesRequest } from '../../../src/main/openai-compat-router/server/request-handler'
+import { handleResponsesRequest } from '../../../src/main/openai-compat-router/server/codex-responses-handler'
+
+function makeRes() {
+  const listeners: Record<string, Array<() => void>> = {}
+  return {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    jsonBody: undefined as unknown,
+    ended: undefined as string | undefined,
+    status(n: number) { this.statusCode = n; return this },
+    setHeader(k: string, v: string) { this.headers[k.toLowerCase()] = v },
+    getHeader(k: string) { return this.headers[k.toLowerCase()] },
+    json(b: unknown) { this.jsonBody = b },
+    end(b?: string) { this.ended = b },
+    on(event: string, cb: () => void) { (listeners[event] ??= []).push(cb) },
+    emit(event: string) { for (const cb of listeners[event] ?? []) cb() },
+  }
+}
+
+function fakeResponse(opts: { ok?: boolean; status?: number; json?: unknown }): globalThis.Response {
+  const h = new Map<string, string>()
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    headers: {
+      forEach: (cb: (v: string, k: string) => void) => h.forEach((v, k) => cb(v, k)),
+      get: (k: string) => h.get(k.toLowerCase()) ?? null,
+    },
+    text: async () => '',
+    json: async () => opts.json ?? {},
+    body: null,
+  } as unknown as globalThis.Response
+}
+
+function baseConfig(over: Record<string, unknown> = {}) {
+  return { url: 'https://halo-cloud.example/v1/llm/chat/completions', key: 'sk-test', ...over } as never
+}
+
+function anthReq(over: Record<string, unknown> = {}) {
+  return {
+    model: 'public',
+    max_tokens: 16,
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: false,
+    ...over,
+  } as never
+}
+
+const CLAUDE_SESSION_HEADER = 'x-claude-code-session-id'
+const CLAUDE_SESSION_VALUE = '58b1790b-0000-4000-8000-000000000001'
+const CODEX_SESSION_HEADER = 'session_id'
+const CODEX_SESSION_VALUE = '019feff6-1690-7fe3-b04e-aed14152d4dd'
+
+function loweredHeaders(call: unknown): Record<string, string> {
+  const outgoing = (call as { headers: Record<string, string> }).headers
+  return Object.fromEntries(
+    Object.entries(outgoing).map(([k, v]) => [k.toLowerCase(), v]),
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  runInterceptors.mockResolvedValue({ intercepted: false, request: anthReq() })
+  normalizeSystemPrompt.mockImplementation((request: unknown) => ({ request, modified: false }))
+  isValidEndpointUrl.mockReturnValue(true)
+  getApiTypeFromUrl.mockReturnValue('chat_completions')
+  shouldForceStream.mockReturnValue(false)
+  isNativeAnthropicHost.mockReturnValue(false)
+  applyProviderAdapter.mockReturnValue(null)
+  convertAnthropicToOpenAIChat.mockReturnValue({ request: { model: 'public', messages: [] } })
+  convertOpenAIChatToAnthropic.mockReturnValue({ type: 'message', content: [] })
+})
+
+describe('pickSessionAffinityHeaders', () => {
+  it('extracts the Claude session header (case-insensitive)', () => {
+    expect(pickSessionAffinityHeaders({ 'X-Claude-Code-Session-Id': 'abc' }))
+      .toEqual({ 'x-claude-code-session-id': 'abc' })
+  })
+
+  it('extracts the Codex session header', () => {
+    expect(pickSessionAffinityHeaders({ Session_id: 'xyz' }))
+      .toEqual({ session_id: 'xyz' })
+  })
+
+  it('drops everything not on the allowlist', () => {
+    expect(pickSessionAffinityHeaders({
+      'x-claude-code-session-id': 'abc',
+      authorization: 'Bearer leak',
+      'anthropic-beta': 'oauth',
+    })).toEqual({ 'x-claude-code-session-id': 'abc' })
+  })
+
+  it('is undefined- and empty-safe', () => {
+    expect(pickSessionAffinityHeaders(undefined)).toEqual({})
+    expect(pickSessionAffinityHeaders({ 'x-claude-code-session-id': '' })).toEqual({})
+  })
+})
+
+describe('session-id header on the halo cloud path (chat_completions conversion)', () => {
+  it('conversion path FORWARDS x-claude-code-session-id to upstream', async () => {
+    const req = anthReq()
+    runInterceptors.mockResolvedValue({ intercepted: false, request: req })
+    proxyFetch.mockResolvedValue(fakeResponse({ ok: true, json: { id: 'x' } }))
+    const res = makeRes()
+
+    await handleMessagesRequest(
+      req,
+      baseConfig({ apiType: 'chat_completions' }),
+      res as unknown as ExpressResponse,
+      { sdkHeaders: { [CLAUDE_SESSION_HEADER]: CLAUDE_SESSION_VALUE } },
+    )
+
+    const lowered = loweredHeaders(proxyFetch.mock.calls[0][1])
+    expect(lowered[CLAUDE_SESSION_HEADER]).toBe(CLAUDE_SESSION_VALUE)
+  })
+
+  it('passthrough path also forwards x-claude-code-session-id to upstream', async () => {
+    const req = anthReq()
+    runInterceptors.mockResolvedValue({ intercepted: false, request: req })
+    proxyFetch.mockResolvedValue(fakeResponse({ ok: true }))
+    const res = makeRes()
+
+    await handleMessagesRequest(
+      req,
+      baseConfig({ apiType: 'anthropic_passthrough', url: 'https://third-party/v1/messages' }),
+      res as unknown as ExpressResponse,
+      { sdkHeaders: { [CLAUDE_SESSION_HEADER]: CLAUDE_SESSION_VALUE } },
+    )
+
+    const lowered = loweredHeaders(proxyFetch.mock.calls[0][1])
+    expect(lowered[CLAUDE_SESSION_HEADER]).toBe(CLAUDE_SESSION_VALUE)
+  })
+})
+
+describe('session-id header on the codex responses conversion path', () => {
+  it('conversion path FORWARDS session_id to upstream', async () => {
+    proxyFetch.mockResolvedValue(fakeResponse({ ok: true, json: { id: 'x' } }))
+    const res = makeRes()
+
+    await handleResponsesRequest(
+      { model: 'public', input: 'hi', stream: false },
+      baseConfig({ apiType: 'chat_completions' }),
+      res as unknown as ExpressResponse,
+      { sdkHeaders: { [CODEX_SESSION_HEADER]: CODEX_SESSION_VALUE } },
+    )
+
+    const lowered = loweredHeaders(proxyFetch.mock.calls[0][1])
+    expect(lowered[CODEX_SESSION_HEADER]).toBe(CODEX_SESSION_VALUE)
+  })
+})


### PR DESCRIPTION
## Related Issue
Per-conversation channel affinity broke for the 行内 (in-bank) client: upstream halo-cloud-ng keys prompt-cache affinity on the SDK session-id header, but the openai-compat-router dropped it on the OpenAI-conversion path.

## Changes
Both SDKs emit a stable per-conversation session id:
- Claude Code SDK → `x-claude-code-session-id`
- Codex SDK → `session_id`

The `anthropic_passthrough` path already forwards all SDK headers, but the OpenAI-conversion paths (`chat_completions` / `responses`) rebuild a minimal header set from provider config and silently dropped these headers, degrading affinity to per-request routing.

This adds a small allowlist helper `pickSessionAffinityHeaders` (closed by default — only the two session-id headers pass) and merges the picked headers onto the upstream request in both conversion handlers:
- `utils/session-affinity.ts` — new allowlist helper
- `server/request-handler.ts` — chat_completions conversion path
- `server/codex-responses-handler.ts` — responses conversion path
- `server/router.ts` — collect SDK headers for `/v1/responses`

## Dev Checklist
- [x] Verified locally with `npm run dev` — drove both paths through the live dev router (port bound at runtime) against a header-logging upstream stand-in; upstream received `x-claude-code-session-id` on the chat path and `session_id` on the responses path
- [x] Ran `/code-review` and addressed valid findings (3-agent consensus: no blockers; the one valid finding — missing codex-responses integration test — was added)
- [x] Ran `/comment-review` to clean up comments
- [x] Committed via `/code-commit` (feature files only; package.json/yarn.lock version bump deliberately excluded)
- [x] Ran `test:unit` (216 compat-router unit tests pass)
- [ ] Ran `test:e2e:smoke` — not run. The smoke project only asserts generic app launch/UI render (window opens, `#root` mounts) and does not exercise the compat-router. It requires a full production build (`prepare:all` + `electron-builder`), and `build:mac` runs `bump-rc`, which would reintroduce the version-bump churn deliberately excluded here. Disproportionate for a header-forwarding change already covered by unit tests + live verification; the template scopes it to large changes.

## Red Lines (common reasons for rejection)
- [x] Code and comments are in English only
- [x] All UI text uses `t('English text')`, no hardcoded strings (no UI changes)
- [x] No unrelated changes, temporary code, or debug statements

---
> 🤖 This PR was prepared with AI assistance (Claude Opus). Human review requested.