### PR TITLE
fix: resolve scene-collection members against the full index and align store funnel event counting

### DIFF
--- a/.claude/skills/halo-dev/ARCHITECTURE.md
+++ b/.claude/skills/halo-dev/ARCHITECTURE.md
@@ -120,6 +120,8 @@ src/
 │       └── *.service.ts + utilities   # Domain singletons: config, conversation, space,
 │                                      #   artifact, artifact-cache, search,
 │                                      #   window, overlay, onboarding, updater, notification,
+│                                      #   announcement (static-feed poll → toast; the only
+│                                      #     server→client push that is not version-coupled),
 │                                      #   protocol, api-validator, model-capabilities,
 │                                      #   secure-storage, browser-view, browser-policy,
 │                                      #   watcher-host
@@ -158,9 +160,11 @@ src/
     │   ├── setup/                     #   Sub-components: LoginSelector, SetupProviderConfig, ServerConnect
     │   ├── store/                     #   App Store UI
     │   ├── ui/                        #   Cross-domain interaction primitives (ConfirmDialog,
-    │   │                              #   ContextMenu, ...). Not shadcn-generated, but follows
-    │   │                              #   the same theme-token pattern. Home for any future
-    │   │                              #   generic primitive (Toast, Popover, Tooltip, ...)
+    │   │                              #   ContextMenu, RichText, ...). Not shadcn-generated,
+    │   │                              #   but follows the same theme-token pattern. Home for
+    │   │                              #   any future generic primitive (Popover, Tooltip, ...)
+    │   │                              #   RichText renders server-authored copy under a hard
+    │   │                              #   element whitelist — never enable raw HTML in it
     │   ├── brand/, icons/, tool/, updater/, notification/
     │   ├── diff/, search/, pulse/, onboarding/, artifact/
     │   └── ErrorBoundary.tsx

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo",
-  "version": "2.1.14-rc.2",
+  "version": "2.1.14-rc.3",
   "description": "AI that gets things done",
   "type": "module",
   "main": "./out/main/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo",
-  "version": "2.1.14-rc.3",
+  "version": "2.1.14-rc.4",
   "description": "AI that gets things done",
   "type": "module",
   "main": "./out/main/index.mjs",

--- a/product.schema.json
+++ b/product.schema.json
@@ -149,6 +149,11 @@
         }
       }
     },
+    "announcementsUrl": {
+      "type": "string",
+      "description": "URL of a static JSON announcement feed (see src/shared/types/announcement.ts). Polled every 6h; new entries are shown as in-app toasts. Omit or leave empty to disable. Independent of updateConfig — release notes only reach users on older versions, this reaches everyone.",
+      "examples": ["https://example.com/announcements.json"]
+    },
     "browserPolicy": {
       "type": "object",
       "description": "Browser network access policy. Controls which domains the embedded browser can navigate to. Omit for unrestricted access (default).",

--- a/src/main/bootstrap/extended.ts
+++ b/src/main/bootstrap/extended.ts
@@ -82,6 +82,7 @@ import {
   getPrimaryRegistry,
 } from '../store'
 import { startUpgradeScheduler, stopUpgradeScheduler } from '../store/upgrade.service'
+import { startAnnouncementScheduler, stopAnnouncementScheduler } from '../services/announcement.service'
 import { cleanupImChannelTempFiles } from '../apps/runtime/im-channels'
 import { registerIdleTask, startIdleDrain } from './idle-queue'
 import { seedDefaultAppIfNeeded } from '../apps/manager/seed'
@@ -185,6 +186,11 @@ async function initPlatformAndApps(): Promise<void> {
   // 6h periodic check + auto-apply for patch/minor on 'auto' strategy.
   // Surfaces 'store:upgrade-available' events for major/notify/manual.
   startUpgradeScheduler()
+
+  // ── Announcement Feed ──────────────────────────────────────────────────
+  // 6h poll of the static feed declared in product.json. No-ops when the
+  // build has no feed configured (open-source default).
+  startAnnouncementScheduler()
 
   // ── Start timer loops AFTER all wiring is complete ──────────────────────
   // This ensures no events fire before subscriptions are registered.
@@ -435,6 +441,9 @@ export async function cleanupExtendedServices(): Promise<void> {
 
   // Store: Stop upgrade scheduler before tearing down registry / app manager
   stopUpgradeScheduler()
+
+  // Announcements: stop polling the feed
+  stopAnnouncementScheduler()
 
   // Store: Shutdown registry service (before app manager)
   shutdownRegistryService()

--- a/src/main/foundation/product-config.ts
+++ b/src/main/foundation/product-config.ts
@@ -199,6 +199,19 @@ export interface ProductConfig {
   /** Browser network access policy (optional, unrestricted when omitted) */
   browserPolicy?: BrowserPolicy
   /**
+   * Announcement feed URL (optional; omitted/empty disables the feature).
+   *
+   * A plain JSON document matching `shared/types/announcement.ts`, served as a
+   * static file — deliberately not an API, so publishing is a file upload and
+   * retracting is emptying the list. Deployments usually point this at the same
+   * static host that serves the update feed.
+   *
+   * Kept separate from `updateConfig` on purpose: release notes only reach users
+   * who are behind on versions, so they cannot carry a message meant for
+   * everyone.
+   */
+  announcementsUrl?: string
+  /**
    * Enterprise service defaults (optional).
    * Pre-populates service configurations so internal users don't need manual setup.
    * Open-source builds omit this field entirely.
@@ -414,6 +427,14 @@ export function getDataFolderName(): string {
  */
 export function getServiceDefaults(): ServiceDefaults | undefined {
   return loadProductConfig().serviceDefaults
+}
+
+/**
+ * Get the announcement feed URL from product.json.
+ * Returns undefined when the feature is not configured for this build.
+ */
+export function getAnnouncementsUrl(): string | undefined {
+  return loadProductConfig().announcementsUrl?.trim() || undefined
 }
 
 /**

--- a/src/main/services/announcement.service.ts
+++ b/src/main/services/announcement.service.ts
@@ -1,0 +1,374 @@
+/**
+ * Announcement Service
+ *
+ * Polls a static JSON feed (`product.json > announcementsUrl`) and surfaces new
+ * entries as in-app toasts. This is the only path that can reach users who are
+ * already on the latest build — update release notes ride a version bump, so
+ * they can never carry a message meant for everyone.
+ *
+ * Design:
+ *   - One singleton interval (default 6h), started from extended bootstrap.
+ *   - Dedup state lives here, not in the renderer: the main process is the
+ *     source of truth, and a renderer-side record would be lost on remote and
+ *     mobile clients that share the same feed.
+ *   - Entries are filtered by schedule window and version range before display,
+ *     so a feed can target "everyone still on an old build" without a server.
+ *
+ * Why this module owns its loop rather than platform/scheduler: the scheduler
+ * surfaces user-defined automation jobs, and a maintenance poll does not belong
+ * in that list. Same rationale as `store/upgrade.service.ts`.
+ *
+ * Trust boundary: feed content is server-authored and, on internal
+ * deployments, travels over plain HTTP. Everything below treats it as
+ * untrusted input — entries are shape-checked, action URLs are protocol-
+ * filtered, and the body is rendered by the restricted `RichText` renderer,
+ * which never executes embedded HTML.
+ */
+
+import { app } from 'electron'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { getAnnouncementsUrl } from '../foundation/product-config'
+import { proxyFetch } from './proxy-fetch'
+import { pushToast } from './notification.service'
+import type { Announcement } from '../../shared/types/announcement'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default poll interval: 6 hours. */
+const DEFAULT_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
+
+/**
+ * Delay before the first poll.
+ *
+ * Short on purpose: the feed is a few-KB conditional GET, too small to matter
+ * against cold start, and holding a maintenance notice back a full minute buys
+ * nothing. The heavy startup work — catalog sync and the installed-app upgrade
+ * check — keeps its own longer deferral.
+ */
+const FIRST_CHECK_DELAY_MS = 5_000
+
+/** A stalled feed host must not hold a socket open indefinitely. */
+const FETCH_TIMEOUT_MS = 10_000
+
+/**
+ * Upper bound on remembered ids.
+ *
+ * Retired announcements are dropped from the feed but their ids must stay
+ * remembered long enough that a slow client does not re-show them. Trimming
+ * oldest-first keeps the file bounded without a expiry-tracking scheme.
+ */
+const MAX_REMEMBERED_IDS = 500
+
+/** Refuse absurdly large feeds rather than parsing them into memory. */
+const MAX_FEED_BYTES = 512 * 1024
+
+const STATE_FILE = 'announcements-state.json'
+
+const SAFE_ACTION_PROTOCOLS = new Set(['http:', 'https:'])
+
+// ============================================================================
+// State
+// ============================================================================
+
+let timer: ReturnType<typeof setInterval> | null = null
+let firstRunTimer: ReturnType<typeof setTimeout> | null = null
+let runningTick = false
+
+/**
+ * ETag of the last successful fetch — deliberately in-memory only.
+ *
+ * Persisting it would let a 304 suppress an entry that was fetched but never
+ * delivered (window closed, crash) on the next launch. Re-downloading a small
+ * static file once per process is the cheaper mistake.
+ */
+let lastEtag: string | null = null
+
+interface PersistedState {
+  /** Ids already shown, oldest first. */
+  shown: string[]
+}
+
+let state: PersistedState | null = null
+
+function getStatePath(): string {
+  return join(app.getPath('userData'), STATE_FILE)
+}
+
+function loadState(): PersistedState {
+  if (state) return state
+
+  try {
+    const path = getStatePath()
+    if (existsSync(path)) {
+      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<PersistedState>
+      state = { shown: Array.isArray(parsed.shown) ? parsed.shown.filter(id => typeof id === 'string') : [] }
+      return state
+    }
+  } catch (error) {
+    console.warn('[Announcement] Could not read state, starting fresh:', error)
+  }
+
+  state = { shown: [] }
+  return state
+}
+
+function saveState(): void {
+  if (!state) return
+  try {
+    const path = getStatePath()
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, JSON.stringify(state), 'utf-8')
+  } catch (error) {
+    // Losing the record only means an announcement may repeat once — never
+    // worth failing the tick over.
+    console.error('[Announcement] Failed to persist state:', error)
+  }
+}
+
+// ============================================================================
+// Filtering
+// ============================================================================
+
+/**
+ * Compare two version strings by their numeric release components.
+ *
+ * Pre-release suffixes are ignored: an `-rc` build is targeted by the same
+ * range as the release it precedes, which is what a feed author expects when
+ * they write `maxVersion: "2.1.13"`.
+ */
+function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => v.split('-')[0].split('.').map(part => parseInt(part, 10) || 0)
+  const left = parse(a)
+  const right = parse(b)
+
+  for (let i = 0; i < 3; i++) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0)
+    if (diff !== 0) return diff < 0 ? -1 : 1
+  }
+  return 0
+}
+
+/** Parse an ISO timestamp, treating anything unparseable as absent. */
+function parseTime(value: string | undefined): number | null {
+  if (!value) return null
+  const time = Date.parse(value)
+  return Number.isNaN(time) ? null : time
+}
+
+/** Structural check — a malformed entry must not take down the whole feed. */
+function isWellFormed(entry: unknown): entry is Announcement {
+  if (!entry || typeof entry !== 'object') return false
+  const candidate = entry as Partial<Announcement>
+  return typeof candidate.id === 'string' && candidate.id.length > 0
+    && typeof candidate.title === 'string' && candidate.title.length > 0
+}
+
+function isDue(entry: Announcement, now: number, currentVersion: string): boolean {
+  const startsAt = parseTime(entry.startsAt)
+  if (startsAt !== null && now < startsAt) return false
+
+  const expiresAt = parseTime(entry.expiresAt)
+  if (expiresAt !== null && now > expiresAt) return false
+
+  if (entry.minVersion && compareVersions(currentVersion, entry.minVersion) < 0) return false
+  if (entry.maxVersion && compareVersions(currentVersion, entry.maxVersion) > 0) return false
+
+  return true
+}
+
+/** Strip an action whose URL is missing or uses a protocol we will not open. */
+function sanitizeAction(action: Announcement['action']): Announcement['action'] {
+  if (!action || typeof action.label !== 'string' || typeof action.url !== 'string') return undefined
+  try {
+    return SAFE_ACTION_PROTOCOLS.has(new URL(action.url).protocol) ? action : undefined
+  } catch {
+    return undefined
+  }
+}
+
+// ============================================================================
+// Fetching
+// ============================================================================
+
+async function fetchFeed(url: string): Promise<Announcement[] | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    const headers: Record<string, string> = { Accept: 'application/json' }
+    if (lastEtag) headers['If-None-Match'] = lastEtag
+
+    const response = await proxyFetch(url, { headers, signal: controller.signal })
+
+    if (response.status === 304) {
+      console.log('[Announcement] Feed unchanged (304)')
+      return null
+    }
+    if (!response.ok) {
+      console.warn(`[Announcement] Feed request failed: ${response.status} ${response.statusText}`)
+      return null
+    }
+
+    const size = Number(response.headers.get('content-length') ?? 0)
+    if (size > MAX_FEED_BYTES) {
+      console.warn(`[Announcement] Feed too large (${size} bytes), ignoring`)
+      return null
+    }
+
+    const text = await response.text()
+    if (text.length > MAX_FEED_BYTES) {
+      console.warn(`[Announcement] Feed body too large (${text.length} bytes), ignoring`)
+      return null
+    }
+
+    const parsed = JSON.parse(text) as unknown
+    // A bare array is accepted so the simplest possible feed is a JSON list.
+    const entries = Array.isArray(parsed)
+      ? parsed
+      : (parsed as { announcements?: unknown })?.announcements
+
+    if (!Array.isArray(entries)) {
+      console.warn('[Announcement] Feed is not a list, ignoring')
+      return null
+    }
+
+    lastEtag = response.headers.get('etag')
+    return entries.filter(isWellFormed)
+  } catch (error) {
+    if (controller.signal.aborted) {
+      console.warn(`[Announcement] Feed request timed out after ${FETCH_TIMEOUT_MS}ms`)
+    } else {
+      console.warn('[Announcement] Feed request error:', error)
+    }
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Fetch the feed and display any entry that is due and not yet shown.
+ *
+ * Coalesces concurrent invocations so a manual trigger cannot double-fire a
+ * scheduled tick. Never throws — a feed problem must not surface to the user.
+ *
+ * @returns How many announcements were displayed in this tick
+ */
+export async function checkAnnouncementsNow(): Promise<number> {
+  const url = getAnnouncementsUrl()
+  if (!url) return 0
+
+  if (runningTick) {
+    console.log('[Announcement] Check already in progress, skipping')
+    return 0
+  }
+  runningTick = true
+
+  try {
+    const entries = await fetchFeed(url)
+    if (!entries) return 0
+
+    const persisted = loadState()
+    const seen = new Set(persisted.shown)
+    const now = Date.now()
+    const currentVersion = app.getVersion()
+
+    const due = entries.filter(entry => !seen.has(entry.id) && isDue(entry, now, currentVersion))
+
+    if (due.length === 0) {
+      console.log(`[Announcement] ${entries.length} entries, none due`)
+      return 0
+    }
+
+    let displayed = 0
+    for (const entry of due) {
+      const delivered = pushToast({
+        id: `announcement-${entry.id}`,
+        title: entry.title,
+        body: entry.body,
+        bodyFormat: entry.bodyFormat ?? 'text',
+        variant: entry.severity ?? 'default',
+        // Sticky: an announcement is rare and must survive the user being away.
+        // It cannot re-appear once dismissed because the id is recorded below.
+        duration: 0,
+        action: sanitizeAction(entry.action),
+      })
+
+      // Only a delivered announcement counts as shown. With the window closed
+      // and no remote client attached the payload is dropped, and recording it
+      // anyway would retire the entry without anyone ever reading it.
+      if (!delivered) {
+        console.log(`[Announcement] Deferred "${entry.id}" — no client received it`)
+        continue
+      }
+
+      persisted.shown.push(entry.id)
+      displayed++
+      console.log(`[Announcement] Displayed "${entry.id}": ${entry.title}`)
+    }
+
+    if (displayed === 0) return 0
+
+    if (persisted.shown.length > MAX_REMEMBERED_IDS) {
+      persisted.shown = persisted.shown.slice(-MAX_REMEMBERED_IDS)
+    }
+    saveState()
+
+    return displayed
+  } catch (error) {
+    console.error('[Announcement] Check failed:', error)
+    return 0
+  } finally {
+    runningTick = false
+  }
+}
+
+/**
+ * Start the periodic announcement poll.
+ *
+ * Idempotent — calling twice replaces the existing timer. No-ops when the build
+ * has no feed configured, which is the open-source default.
+ */
+export function startAnnouncementScheduler(opts?: { intervalMs?: number }): void {
+  stopAnnouncementScheduler()
+
+  const url = getAnnouncementsUrl()
+  if (!url) {
+    console.log('[Announcement] No feed configured, scheduler disabled')
+    return
+  }
+
+  const intervalMs = opts?.intervalMs && opts.intervalMs > 0
+    ? opts.intervalMs
+    : DEFAULT_CHECK_INTERVAL_MS
+
+  console.log(`[Announcement] Starting scheduler (interval=${intervalMs}ms, first run in ${FIRST_CHECK_DELAY_MS}ms)`)
+
+  firstRunTimer = setTimeout(() => {
+    void checkAnnouncementsNow()
+  }, FIRST_CHECK_DELAY_MS)
+
+  timer = setInterval(() => {
+    void checkAnnouncementsNow()
+  }, intervalMs)
+}
+
+/** Stop the periodic announcement poll. */
+export function stopAnnouncementScheduler(): void {
+  if (firstRunTimer) {
+    clearTimeout(firstRunTimer)
+    firstRunTimer = null
+  }
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+    console.log('[Announcement] Scheduler stopped')
+  }
+}

--- a/src/main/services/notification.service.ts
+++ b/src/main/services/notification.service.ts
@@ -19,7 +19,8 @@
 import { Notification } from 'electron'
 import { getConfig } from '../foundation/config.service'
 import { getMainWindow, sendToRenderer } from '../foundation/window.service'
-import { broadcastToAll } from '../http/websocket'
+import { broadcastToAll, getAuthenticatedClientCount } from '../http/websocket'
+import type { ToastPayload } from '../../shared/types/notification'
 
 // ── Helpers ────────────────────────────────────────────
 
@@ -32,32 +33,38 @@ function isWindowFocused(): boolean {
 }
 
 /**
- * Send an in-app toast to the renderer process.
- * The renderer's NotificationToast component picks this up via the notification store.
+ * Push an in-app toast to every connected client.
+ *
+ * Delivery is dual: IPC for the Electron renderer, WebSocket for remote and
+ * mobile clients. Callers that only want the desktop window should not use
+ * this.
+ *
+ * @returns whether at least one surface received it. A closed main window with
+ * no remote clients silently drops the payload, so any caller that records the
+ * toast as delivered (announcement dedup) must gate on this.
  */
-function sendInAppToast(
-  title: string,
-  body: string,
-  options?: { appId?: string; variant?: 'default' | 'success' | 'warning' | 'error'; duration?: number }
-): void {
-  const payload = {
-    title,
-    body,
-    variant: options?.variant ?? 'default',
-    duration: options?.duration ?? 0,
-    appId: options?.appId,
+export function pushToast(payload: ToastPayload): boolean {
+  const message: ToastPayload = {
+    ...payload,
+    variant: payload.variant ?? 'default',
+    duration: payload.duration ?? 0,
   }
 
-  // 1. Send to Electron renderer via IPC (desktop)
-  const sent = sendToRenderer('notification:toast', payload)
-  console.log(`[Notification] In-app toast sent=${sent}: title="${title}"`)
+  const sentToRenderer = sendToRenderer('notification:toast', message)
 
-  // 2. Broadcast to remote/mobile WebSocket clients
+  let remoteClients = 0
   try {
-    broadcastToAll('notification:toast', payload as unknown as Record<string, unknown>)
+    broadcastToAll('notification:toast', message as unknown as Record<string, unknown>)
+    remoteClients = getAuthenticatedClientCount()
   } catch {
     // WebSocket module might not be initialized yet, ignore
   }
+
+  const delivered = sentToRenderer || remoteClients > 0
+  console.log(
+    `[Notification] In-app toast delivered=${delivered} (renderer=${sentToRenderer}, remote=${remoteClients}): title="${message.title}"`
+  )
+  return delivered
 }
 
 // ── Public API ─────────────────────────────────────────
@@ -141,10 +148,10 @@ export function notifyAppEvent(title: string, body: string, options?: AppNotific
     if (focused) {
       // Window is focused — macOS suppresses OS notifications for foreground apps.
       // Send an in-app toast instead so the user always sees it.
-      sendInAppToast(title, body, { appId: options?.appId, variant: 'default' })
+      pushToast({ title, body, appId: options?.appId })
     } else if (!Notification.isSupported()) {
       console.warn('[Notification] Notification.isSupported() = false — falling back to in-app toast')
-      sendInAppToast(title, body, { appId: options?.appId, variant: 'default' })
+      pushToast({ title, body, appId: options?.appId })
     } else {
       try {
         const mainWindow = getMainWindow()
@@ -172,7 +179,7 @@ export function notifyAppEvent(title: string, body: string, options?: AppNotific
       } catch (error) {
         console.error('[Notification] Failed to show app event notification:', error)
         // Fallback to in-app toast if OS notification fails
-        sendInAppToast(title, body, { appId: options?.appId, variant: 'default' })
+        pushToast({ title, body, appId: options?.appId })
       }
     }
   }

--- a/src/main/store/DESIGN.md
+++ b/src/main/store/DESIGN.md
@@ -296,6 +296,14 @@ curated slug list that is authoritative for both membership and order). It is
 deliberately **not** in `shared/`: nothing outside this process resolves
 sections, and putting it in `shared/` would invite a renderer to try.
 
+**Collection membership resolves here too**, for the same reason and by the same
+rule. A collection travels from ops as slugs; the payload carries the entries.
+Resolving slugs in the renderer looks harmless — it is a map lookup — but the
+only map available there is the browse list, so a collection curated with more
+members than fit on catalog page 1 renders as however many happen to land in it.
+The type says so: `ResolvedDiscoverNode.collections` is `ResolvedCollection[]`,
+which carries `entries`, and the renderer has no way to build one.
+
 ### 3.11 Freshness is triggered by the user arriving, not by a timer
 
 Everything the store shows is cached — the index in SQLite, the page documents

--- a/src/main/store/discover-page.ts
+++ b/src/main/store/discover-page.ts
@@ -19,6 +19,7 @@ import { BUILTIN_DISCOVER_LAYOUT } from '../../shared/store/store-types'
 import type {
   DiscoverNode,
   RegistryEntry,
+  ResolvedCollection,
   ResolvedDiscover,
   ResolvedDiscoverNode,
   StoreCollection,
@@ -111,11 +112,36 @@ function resolveNode(node: DiscoverNode, ctx: ResolveContext): ResolvedDiscoverN
   }
 
   if (node.layout === 'collections') {
-    return ctx.collections.length > 0 ? { ...base, collections: ctx.collections } : null
+    const collections = resolveCollections(ctx.collections, ctx.entries)
+    return collections.length > 0 ? { ...base, collections } : null
   }
 
   const entries = resolveSection(node.source, ctx.entries)
   return entries.length > 0 ? { ...base, entries } : null
+}
+
+/**
+ * A collection is a curated slug list, which is the section semantics a
+ * `slugs` source already expresses — so it resolves through the same code
+ * rather than a second copy of it.
+ *
+ * A member the index does not carry — unpublished since it was curated, or
+ * never synced — drops out, but is counted in a warning: a curated list quietly
+ * losing members is otherwise invisible to whoever configured it.
+ */
+function resolveCollections(collections: StoreCollection[], entries: RegistryEntry[]): ResolvedCollection[] {
+  const out: ResolvedCollection[] = []
+  for (const { memberSlugs, ...collection } of collections) {
+    const members = resolveSection({ slugs: memberSlugs }, entries)
+    const missing = memberSlugs.length - members.length
+    if (missing > 0) {
+      console.warn(
+        `[discover-page] collection "${collection.id}": ${missing}/${memberSlugs.length} members not in the index`,
+      )
+    }
+    if (members.length > 0) out.push({ ...collection, entries: members })
+  }
+  return out
 }
 
 function hasCollectionsSection(node: DiscoverNode): boolean {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -40,6 +40,7 @@ import { useTranslation } from './i18n'
 import type { AgentEventBase, Thought, ToolCall, HaloConfig, AgentErrorType, Question, McpServerStatus } from './types'
 import type { SessionInitInfo } from './types/slash-command'
 import type { IngestProgressEvent } from '../shared/types/tlon'
+import type { ToastPayload } from '../shared/types/notification'
 import { hasAnyAISource } from './types'
 
 // Lazy load heavy page components for better initial load performance
@@ -724,24 +725,30 @@ export default function App() {
   const showToast = useNotificationStore((s) => s.show)
   useEffect(() => {
     const unsub = api.onNotificationToast((data) => {
-      const { title, body, variant, duration, appId } = data as {
-        title: string; body?: string; variant?: 'default' | 'success' | 'warning' | 'error'; duration?: number; appId?: string
-      }
-      showToast({
-        title,
-        body,
-        variant: variant ?? 'default',
-        duration: duration ?? 6000,
-        // If appId is provided, add a "View" action for deep navigation
-        ...(appId ? {
-          action: {
+      const { id, title, body, bodyFormat, variant, duration, appId, action } = data as ToastPayload
+
+      // A declared link action wins over app deep-navigation: the sender asked
+      // for a specific destination, which appId can only approximate.
+      const resolvedAction = action
+        ? { label: action.label, onClick: () => { window.open(action.url, '_blank') } }
+        : appId
+          ? {
             label: t('View'),
             onClick: () => {
               setInitialAppId(appId)
               setView('apps')
             },
-          },
-        } : {}),
+          }
+          : undefined
+
+      showToast({
+        ...(id ? { id } : {}),
+        title,
+        body,
+        bodyFormat,
+        variant: variant ?? 'default',
+        duration: duration ?? 6000,
+        ...(resolvedAction ? { action: resolvedAction } : {}),
       })
     })
     return () => { unsub() }

--- a/src/renderer/components/notification/NotificationToast.tsx
+++ b/src/renderer/components/notification/NotificationToast.tsx
@@ -11,9 +11,15 @@
  * Mount once in App.tsx — it reads from useNotificationStore.
  */
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, lazy, Suspense } from 'react'
 import { X, Bell, CheckCircle2, AlertTriangle, AlertCircle } from 'lucide-react'
 import { useNotificationStore, type ToastItem, type ToastVariant } from '../../stores/notification.store'
+
+// This component is mounted at the app root, so a static import would pull the
+// markdown parser into the entry chunk for a surface most sessions never show
+// rich copy in. The fallback renders the same text unparsed, which stays
+// readable for the moment the chunk takes to arrive.
+const RichText = lazy(() => import('../ui/RichText').then(m => ({ default: m.RichText })))
 
 // ── Variant config ──────────────────────────────────────
 
@@ -67,10 +73,13 @@ function Toast({ toast }: { toast: ToastItem }) {
   }, [toast.duration, handleDismiss])
 
   const style = variantStyles[toast.variant]
+  // Server-authored copy is structured and usually longer, so it earns the
+  // wider card. Plain one-line toasts keep the original width.
+  const isRich = toast.bodyFormat === 'markdown'
 
   return (
     <div className="animate-in slide-in-from-bottom-4 fade-in duration-300 pointer-events-auto">
-      <div className="bg-zinc-800 border border-zinc-700 rounded-lg shadow-xl p-4 max-w-sm">
+      <div className={`bg-zinc-800 border border-zinc-700 rounded-lg shadow-xl p-4 w-full sm:w-auto ${isRich ? 'sm:max-w-md' : 'sm:max-w-sm'}`}>
         <div className="flex items-start gap-3">
           {/* Icon */}
           <div className={`flex-shrink-0 w-10 h-10 ${style.bg} rounded-full flex items-center justify-center`}>
@@ -81,7 +90,15 @@ function Toast({ toast }: { toast: ToastItem }) {
           <div className="flex-1 min-w-0">
             <h4 className="text-sm font-medium text-zinc-100">{toast.title}</h4>
             {toast.body && (
-              <p className="text-xs text-zinc-400 mt-1 line-clamp-3">{toast.body}</p>
+              <div className="mt-1 max-h-32 overflow-y-auto text-xs text-zinc-400">
+                {isRich
+                  ? (
+                    <Suspense fallback={<p className="whitespace-pre-line">{toast.body}</p>}>
+                      <RichText content={toast.body} />
+                    </Suspense>
+                  )
+                  : <p className="whitespace-pre-line">{toast.body}</p>}
+              </div>
             )}
 
             {/* Actions */}
@@ -136,7 +153,7 @@ export function NotificationToast() {
   if (toasts.length === 0) return null
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+    <div className="fixed bottom-4 inset-x-4 sm:inset-x-auto sm:right-4 z-50 flex flex-col items-stretch sm:items-end gap-2 pointer-events-none">
       {toasts.map((toast) => (
         <Toast key={toast.id} toast={toast} />
       ))}

--- a/src/renderer/components/store/StoreDetail.tsx
+++ b/src/renderer/components/store/StoreDetail.tsx
@@ -103,16 +103,6 @@ export function StoreDetail() {
 
   const { installedApp, updateInfo } = useStoreEntryInstallState(entry, registryId)
 
-  // Store funnel: a detail page opened, tagged with the install state.
-  useEffect(() => {
-    if (!entry) return
-    void api.trackEvent('store.detail.view', {
-      appId: entry.slug,
-      appType: entry.type,
-      installedState: updateInfo ? 'update' : installedApp ? 'installed' : 'new',
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entry?.slug])
   const { start: startUpdate, busy: updating, dialogs: updateDialogs } = useStoreUpdateFlow(
     entry,
     updateInfo,
@@ -238,7 +228,7 @@ export function StoreDetail() {
             <p className="text-xs text-muted-foreground/60 mt-1 max-w-xs">{storeDetailError}</p>
           </div>
           <button
-            onClick={() => storeSelectedSlug && void selectStoreApp(storeSelectedSlug)}
+            onClick={() => storeSelectedSlug && void selectStoreApp(storeSelectedSlug, false, 'reload')}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground border border-border/60 rounded-lg hover:bg-secondary transition-colors"
           >
             <RotateCcw className="w-3.5 h-3.5" />

--- a/src/renderer/components/store/StoreDetail.tsx
+++ b/src/renderer/components/store/StoreDetail.tsx
@@ -228,7 +228,7 @@ export function StoreDetail() {
             <p className="text-xs text-muted-foreground/60 mt-1 max-w-xs">{storeDetailError}</p>
           </div>
           <button
-            onClick={() => storeSelectedSlug && void selectStoreApp(storeSelectedSlug, false, 'reload')}
+            onClick={() => storeSelectedSlug && void selectStoreApp(storeSelectedSlug)}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground border border-border/60 rounded-lg hover:bg-secondary transition-colors"
           >
             <RotateCcw className="w-3.5 h-3.5" />

--- a/src/renderer/components/store/StoreDiscover.tsx
+++ b/src/renderer/components/store/StoreDiscover.tsx
@@ -8,13 +8,13 @@
  * renders here always has something to show.
  */
 
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { X } from 'lucide-react'
 import { api } from '../../api'
 import { useAppsPageStore } from '../../stores/apps-page.store'
 import { useDiscoverPage } from '../../hooks/useDiscoverPage'
 import { useCategoryLabel } from '../../hooks/useStoreCategories'
-import type { RegistryEntry, StoreCollection, ResolvedDiscoverNode } from '../../../shared/store/store-types'
+import type { RegistryEntry, ResolvedCollection, ResolvedDiscoverNode } from '../../../shared/store/store-types'
 import { StoreCard } from './StoreCard'
 import { StoreGrid } from './StoreGrid'
 import { RankBoard, rankBoardEntries, MIN_RANK_ENTRIES } from './RankBoard'
@@ -92,14 +92,11 @@ function FeaturedCard({ entry, onSelect }: { entry: RegistryEntry; onSelect: () 
   )
 }
 
-function CollectionCard({ collection, bySlug }: { collection: StoreCollection; bySlug: Map<string, RegistryEntry> }) {
+function CollectionCard({ collection }: { collection: ResolvedCollection }) {
   const { t } = useTranslation()
   const selectStoreApp = useAppsPageStore(state => state.selectStoreApp)
   const [open, setOpen] = useState(false)
-  const previewMembers = collection.memberSlugs
-    .map(slug => bySlug.get(slug))
-    .filter((e): e is RegistryEntry => !!e)
-    .slice(0, 3)
+  const previewMembers = collection.entries.slice(0, 3)
 
   return (
     <>
@@ -125,14 +122,13 @@ function CollectionCard({ collection, bySlug }: { collection: StoreCollection; b
             ))}
           </div>
           <span className="text-xs text-muted-foreground">
-            {t('{{count}} apps', { count: collection.memberSlugs.length })}
+            {t('{{count}} apps', { count: collection.entries.length })}
           </span>
         </div>
       </button>
       {open && (
         <CollectionDialog
           collection={collection}
-          bySlug={bySlug}
           onClose={() => setOpen(false)}
           onSelect={slug => { setOpen(false); selectStoreApp(slug) }}
         />
@@ -143,19 +139,15 @@ function CollectionCard({ collection, bySlug }: { collection: StoreCollection; b
 
 function CollectionDialog({
   collection,
-  bySlug,
   onClose,
   onSelect,
 }: {
-  collection: StoreCollection
-  bySlug: Map<string, RegistryEntry>
+  collection: ResolvedCollection
   onClose: () => void
   onSelect: (slug: string) => void
 }) {
   const { t } = useTranslation()
-  const members = collection.memberSlugs
-    .map(slug => bySlug.get(slug))
-    .filter((e): e is RegistryEntry => !!e)
+  const members = collection.entries
 
   return (
     <div
@@ -187,15 +179,11 @@ function CollectionDialog({
           </button>
         </div>
         <div className="flex-1 overflow-y-auto p-4 bg-background">
-          {members.length === 0 ? (
-            <div className="text-center text-sm text-muted-foreground py-10">{t('No apps in this collection yet')}</div>
-          ) : (
-            <div className="grid grid-cols-1 gap-3">
-              {members.map(entry => (
-                <StoreCard key={entry.slug} entry={entry} source="collection" onClick={() => onSelect(entry.slug)} />
-              ))}
-            </div>
-          )}
+          <div className="grid grid-cols-1 gap-3">
+            {members.map(entry => (
+              <StoreCard key={entry.slug} entry={entry} source="collection" onClick={() => onSelect(entry.slug)} />
+            ))}
+          </div>
         </div>
       </div>
     </div>
@@ -210,13 +198,11 @@ function CollectionDialog({
 function SectionBody({ node, padded }: { node: ResolvedDiscoverNode; padded?: boolean }) {
   const { t } = useTranslation()
   const locale = getCurrentLanguage()
-  const storeApps = useAppsPageStore(state => state.storeApps)
   const seedStoreApps = useAppsPageStore(state => state.seedStoreApps)
   const collections = node.collections ?? []
   const title = resolveLocaleText(node.title, locale)
   const subtitle = resolveLocaleText(node.subtitle, locale)
   const entries = node.entries ?? []
-  const bySlug = useMemo(() => new Map(storeApps.map(e => [e.slug, e])), [storeApps])
 
   // Keep the browse list in step with the catalog page that travelled with the
   // payload, so the grid and the curated sections describe the same snapshot.
@@ -243,7 +229,7 @@ function SectionBody({ node, padded }: { node: ResolvedDiscoverNode; padded?: bo
       <>
         <SectionLabel sub={subtitle}>{title ?? t('Scene Collections')}</SectionLabel>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {collections.map(c => <CollectionCard key={c.id} collection={c} bySlug={bySlug} />)}
+          {collections.map(c => <CollectionCard key={c.id} collection={c} />)}
         </div>
       </>,
     )

--- a/src/renderer/components/store/StoreDiscover.tsx
+++ b/src/renderer/components/store/StoreDiscover.tsx
@@ -55,7 +55,14 @@ function FeaturedGrid({ entries }: { entries: RegistryEntry[] }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
       {entries.map(entry => (
-        <FeaturedCard key={entry.slug} entry={entry} onSelect={() => selectStoreApp(entry.slug)} />
+        <FeaturedCard
+          key={entry.slug}
+          entry={entry}
+          onSelect={() => {
+            void api.trackEvent('store.card.click', { appId: entry.slug, appType: entry.type, source: 'featured' })
+            selectStoreApp(entry.slug)
+          }}
+        />
       ))}
     </div>
   )

--- a/src/renderer/components/store/StoreMine.tsx
+++ b/src/renderer/components/store/StoreMine.tsx
@@ -130,9 +130,10 @@ export function StoreMine() {
     else showToast({ title: res.error || t('Take down failed. Please try again.'), variant: 'error', duration: 4000 })
   }, [load, showConfirm, showToast, t])
 
-  // Tagged `mine` so the browse funnel can exclude it: an author reopening their
-  // own publication is not catalog traffic, but it does open a detail, so it has
-  // to be emitted for the click and view sides to cover the same openings.
+  // Emitted so that every opened detail has a click behind it. `source` records
+  // that this one is an author reopening their own publication rather than
+  // catalog traffic; nothing splits the funnel on it today, so these clicks do
+  // count towards the store-wide click rate.
   //
   // A publication carries no type once it leaves the public index — which is
   // exactly the taken-down state this page exists to show. The dimension is left

--- a/src/renderer/components/store/StoreMine.tsx
+++ b/src/renderer/components/store/StoreMine.tsx
@@ -130,18 +130,17 @@ export function StoreMine() {
     else showToast({ title: res.error || t('Take down failed. Please try again.'), variant: 'error', duration: 4000 })
   }, [load, showConfirm, showToast, t])
 
-  // Reported like any other card click, tagged `mine` so the browse funnel can
-  // exclude it at query time. Emitting it keeps click ≥ view true everywhere,
-  // which is what makes an inverted ratio readable as a missing event rather
-  // than as a surface that was never instrumented.
+  // Tagged `mine` so the browse funnel can exclude it: an author reopening their
+  // own publication is not catalog traffic, but it does open a detail, so it has
+  // to be emitted for the click and view sides to cover the same openings.
   //
   // A publication carries no type once it leaves the public index — which is
-  // exactly the taken-down state this page exists to show — so the dimension
-  // says so rather than arriving empty and reading as a gap in the pipeline.
+  // exactly the taken-down state this page exists to show. The dimension is left
+  // off there rather than filled with a value that is not an app type.
   const openDetail = useCallback((pub: MyPublication) => {
     void api.trackEvent('store.card.click', {
       appId: pub.slug,
-      appType: pub.type ?? 'unlisted',
+      ...(pub.type ? { appType: pub.type } : {}),
       source: 'mine',
     })
     void selectStoreApp(pub.slug)

--- a/src/renderer/components/store/StoreMine.tsx
+++ b/src/renderer/components/store/StoreMine.tsx
@@ -130,6 +130,23 @@ export function StoreMine() {
     else showToast({ title: res.error || t('Take down failed. Please try again.'), variant: 'error', duration: 4000 })
   }, [load, showConfirm, showToast, t])
 
+  // Reported like any other card click, tagged `mine` so the browse funnel can
+  // exclude it at query time. Emitting it keeps click ≥ view true everywhere,
+  // which is what makes an inverted ratio readable as a missing event rather
+  // than as a surface that was never instrumented.
+  //
+  // A publication carries no type once it leaves the public index — which is
+  // exactly the taken-down state this page exists to show — so the dimension
+  // says so rather than arriving empty and reading as a gap in the pipeline.
+  const openDetail = useCallback((pub: MyPublication) => {
+    void api.trackEvent('store.card.click', {
+      appId: pub.slug,
+      appType: pub.type ?? 'unlisted',
+      source: 'mine',
+    })
+    void selectStoreApp(pub.slug)
+  }, [selectStoreApp])
+
   const openPublish = useCallback((pub: MyPublication) => {
     setPublishType(pub.type === 'skill' || pub.type === 'automation' ? pub.type : undefined)
     setPublishTarget({
@@ -240,7 +257,7 @@ export function StoreMine() {
                           key={`${pub.slug}@${pub.version}`}
                           pub={pub}
                           busy={busySlug === pub.slug}
-                          onOpen={() => void selectStoreApp(pub.slug)}
+                          onOpen={() => openDetail(pub)}
                           onUnpublish={() => handleUnpublish(pub.slug)}
                           onPublishVersion={() => openPublish(pub)}
                         />

--- a/src/renderer/components/ui/RichText.tsx
+++ b/src/renderer/components/ui/RichText.tsx
@@ -1,0 +1,109 @@
+/**
+ * RichText — restricted markdown for short, untrusted copy.
+ *
+ * Sized for compact surfaces (toasts, banners) and hardened for content that
+ * arrives from a server rather than from the user: update release notes and
+ * the announcement feed are both authored outside the app and delivered over
+ * plain HTTP on internal deployments.
+ *
+ * Three boundaries make that safe, and none of them may be relaxed without a
+ * security review:
+ * 1. `allowedElements` is a whitelist. `img` is absent on purpose — a remote
+ *    image is a tracking beacon and an unbounded layout hazard. Headings and
+ *    tables are absent because they cannot render sanely at this size.
+ * 2. `skipHtml` plus the absence of `rehype-raw` means embedded HTML is
+ *    dropped, never executed. The renderer holds privileged bridge APIs, so an
+ *    injected script would be arbitrary code execution, not a cosmetic bug.
+ * 3. `urlTransform` allows only http/https/mailto, so `javascript:` and
+ *    `file:` hrefs cannot survive into the DOM.
+ *
+ * For long-form assistant output use `chat/MarkdownRenderer` instead — it is
+ * built for streaming and carries syntax highlighting and math.
+ */
+
+import { memo } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+/** Elements this renderer will emit. Anything else is unwrapped to its text. */
+const ALLOWED_ELEMENTS = [
+  'p', 'br', 'strong', 'em', 'del', 'code',
+  'ul', 'ol', 'li', 'a', 'blockquote',
+]
+
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:'])
+
+/**
+ * Drop any href whose protocol is not explicitly safe.
+ *
+ * Relative URLs have no meaning here (there is no server origin to resolve
+ * against), so anything unparseable is dropped rather than passed through.
+ */
+function safeUrl(url: string): string {
+  try {
+    return SAFE_PROTOCOLS.has(new URL(url).protocol) ? url : ''
+  } catch {
+    return ''
+  }
+}
+
+const components = {
+  p: ({ children }: { children?: React.ReactNode }) => (
+    <p className="mb-1.5 last:mb-0">{children}</p>
+  ),
+  ul: ({ children }: { children?: React.ReactNode }) => (
+    <ul className="mb-1.5 last:mb-0 pl-4 space-y-0.5 list-disc">{children}</ul>
+  ),
+  ol: ({ children }: { children?: React.ReactNode }) => (
+    <ol className="mb-1.5 last:mb-0 pl-4 space-y-0.5 list-decimal">{children}</ol>
+  ),
+  li: ({ children }: { children?: React.ReactNode }) => (
+    <li className="leading-relaxed">{children}</li>
+  ),
+  strong: ({ children }: { children?: React.ReactNode }) => (
+    <strong className="font-semibold">{children}</strong>
+  ),
+  // Colours are deliberately inherited rather than themed: this renderer is
+  // dropped into surfaces that set their own foreground (the toast card paints
+  // its own dark background), so anything absolute would break on one of them.
+  code: ({ children }: { children?: React.ReactNode }) => (
+    <code className="font-mono text-[0.9em]">{children}</code>
+  ),
+  blockquote: ({ children }: { children?: React.ReactNode }) => (
+    <blockquote className="my-1.5 pl-2 border-l-2 border-current opacity-80">{children}</blockquote>
+  ),
+  a: ({ href, children }: { href?: string; children?: React.ReactNode }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-2 hover:opacity-80"
+    >
+      {children}
+    </a>
+  ),
+}
+
+interface RichTextProps {
+  content: string
+  className?: string
+}
+
+export const RichText = memo(function RichText({ content, className = '' }: RichTextProps) {
+  if (!content) return null
+
+  return (
+    <div className={`break-words ${className}`}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        allowedElements={ALLOWED_ELEMENTS}
+        unwrapDisallowed
+        skipHtml
+        urlTransform={safeUrl}
+        components={components}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+})

--- a/src/renderer/components/updater/UpdateNotification.tsx
+++ b/src/renderer/components/updater/UpdateNotification.tsx
@@ -1,17 +1,19 @@
 /**
  * Update Notification Listener
  *
- * Listens for updater IPC events and drives a single toast through the whole
- * update lifecycle: found -> downloading -> ready to apply. One stable toast id
- * means the states replace each other in place rather than stacking.
+ * Surfaces exactly one toast, and only once the update has stopped needing the
+ * user's patience: either it is staged and ready to apply, or it failed and the
+ * download page is the way out. Checking and downloading stay silent — the user
+ * cannot pause, cancel or speed up a background download, so a progress toast
+ * would occupy a corner of the screen for minutes while offering no action.
  *
  * 'manual-download' is the degraded path: the main process emits it when an
  * announced update could not be downloaded or staged, so the user is handed the
  * download page instead of a progress bar that never finishes.
  *
- * The final prompt is sticky — the user either applies the update or defers it
- * for the day. Deferral is remembered per version so the hourly re-check does
- * not re-open a prompt the user already answered.
+ * The prompt is sticky — the user either applies the update or defers it for the
+ * day. Deferral is remembered per version so the hourly re-check does not
+ * re-open a prompt the user already answered.
  */
 
 import { useEffect, useRef } from 'react'
@@ -44,22 +46,30 @@ function snooze(version: string): void {
   }
 }
 
-// Parse release notes to a single summary string
+/**
+ * Normalize release notes into a markdown list.
+ *
+ * The feed carries either a plain string (one change per line, bulleted or not)
+ * or electron-updater's per-version array. Re-bulleting every line makes the
+ * two shapes render identically instead of depending on how the release was
+ * authored. Tags are stripped because the GitHub provider falls back to the raw
+ * release body, which can carry markup the restricted renderer would drop
+ * mid-sentence.
+ */
 function formatReleaseNotes(notes: string | { version: string; note: string }[] | undefined): string {
   if (!notes) return ''
 
-  let lines: string[] = []
-  if (typeof notes === 'string') {
-    lines = notes
-      .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.length > 0)
-      .map(line => line.replace(/^[-*]\s*/, ''))
-  } else if (Array.isArray(notes)) {
-    lines = notes.map(item => item.note)
-  }
+  const lines = typeof notes === 'string'
+    ? notes.split('\n')
+    : Array.isArray(notes)
+      ? notes.map(item => item.note)
+      : []
 
-  return lines.length > 0 ? lines.join(' · ') : ''
+  return lines
+    .map(line => line.replace(/<[^>]*>/g, '').trim())
+    .filter(line => line.length > 0)
+    .map(line => `- ${line.replace(/^[-*+]\s*/, '')}`)
+    .join('\n')
 }
 
 export function UpdateNotification() {
@@ -80,37 +90,17 @@ export function UpdateNotification() {
         label: t("Don't remind me today"),
         onClick: () => snooze(version),
       }
-
-      if (data.status === 'available') {
-        show({
-          id: UPDATE_TOAST_ID,
-          title,
-          body: t('Downloading in the background…'),
-          variant: 'success',
-          duration: 0,
-        })
-        return
-      }
-
-      if (data.status === 'downloading') {
-        show({
-          id: UPDATE_TOAST_ID,
-          title,
-          body: t('Downloading… {{percent}}%', { percent: Math.round(data.percent ?? 0) }),
-          variant: 'success',
-          duration: 0,
-        })
-        return
-      }
+      const notes = formatReleaseNotes(data.releaseNotes)
 
       if (data.status === 'downloaded') {
         const isInstaller = data.installMode === 'installer'
         show({
           id: UPDATE_TOAST_ID,
           title,
-          body: formatReleaseNotes(data.releaseNotes) || (isInstaller
+          body: notes || (isInstaller
             ? t('Halo will close and the installer will guide you through it')
             : t('Applies in a few seconds, then Halo reopens')),
+          bodyFormat: notes ? 'markdown' : 'text',
           variant: 'success',
           duration: 0,
           action: {

--- a/src/renderer/i18n/locales/de.json
+++ b/src/renderer/i18n/locales/de.json
@@ -528,8 +528,6 @@
   "Download": "Herunterladen",
   "Download and install manually": "Manuell herunterladen und installieren",
   "Downloading {{version}}… {{percent}}%": "Herunterladen {{version}}… {{percent}}%",
-  "Downloading in the background…": "Herunterladen im Hintergrund…",
-  "Downloading… {{percent}}%": "Herunterladen… {{percent}}%",
   "Draft a reusable weekly report template": "Entwerfen Sie eine wiederverwendbare Wochenbericht-Vorlage",
   "Drag to resize": "Ziehen zum Ändern der Größe",
   "Drag to resize width": "Ziehen zum Ändern der Breite",

--- a/src/renderer/i18n/locales/de.json
+++ b/src/renderer/i18n/locales/de.json
@@ -961,7 +961,6 @@
   "No AI sources configured": "Keine KI-Quellen konfiguriert",
   "No answer was produced.": "Es wurde keine Antwort erzeugt.",
   "No apps found": "Keine Apps gefunden",
-  "No apps in this collection yet": "Noch keine Apps in dieser Sammlung",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "Keine automatischen Upgrade-Prüfungen. Verwenden Sie „Auf Updates prüfen“, um bei Bedarf zu aktualisieren.",
   "No Bot instances configured. Click the button below to add one.": "Keine Bot-Instanzen konfiguriert. Klicken Sie unten auf die Schaltfläche, um eine hinzuzufügen.",
   "No changes": "Keine Änderungen",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -961,7 +961,6 @@
   "No AI sources configured": "No AI sources configured",
   "No answer was produced.": "No answer was produced.",
   "No apps found": "No apps found",
-  "No apps in this collection yet": "No apps in this collection yet",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "No automatic upgrade checks. Use Check for upgrades to update on demand.",
   "No Bot instances configured. Click the button below to add one.": "No Bot instances configured. Click the button below to add one.",
   "No changes": "No changes",

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -528,8 +528,6 @@
   "Download": "Download",
   "Download and install manually": "Download and install manually",
   "Downloading {{version}}… {{percent}}%": "Downloading {{version}}… {{percent}}%",
-  "Downloading in the background…": "Downloading in the background…",
-  "Downloading… {{percent}}%": "Downloading… {{percent}}%",
   "Draft a reusable weekly report template": "Draft a reusable weekly report template",
   "Drag to resize": "Drag to resize",
   "Drag to resize width": "Drag to resize width",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -1012,7 +1012,6 @@
   "No AI sources configured": "No hay fuentes de IA configuradas",
   "No answer was produced.": "No se generó ninguna respuesta.",
   "No apps found": "No se encontraron apps",
-  "No apps in this collection yet": "Aún no hay apps en esta colección",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "Sin comprobaciones automáticas de actualización. Usa 'Buscar actualizaciones' para actualizar bajo demanda.",
   "No Bot instances configured. Click the button below to add one.": "No hay instancias de Bot configuradas. Haz clic en el botón de abajo para añadir una.",
   "No changes": "Sin cambios",

--- a/src/renderer/i18n/locales/es.json
+++ b/src/renderer/i18n/locales/es.json
@@ -568,8 +568,6 @@
   "Download": "Descargar",
   "Download and install manually": "Descargar e instalar manualmente",
   "Downloading {{version}}… {{percent}}%": "Descargando {{version}}… {{percent}}%",
-  "Downloading in the background…": "Descargando en segundo plano…",
-  "Downloading… {{percent}}%": "Descargando… {{percent}}%",
   "Draft a reusable weekly report template": "Crea una plantilla de informe semanal reutilizable",
   "Drag to resize": "Arrastra para redimensionar",
   "Drag to resize width": "Arrastra para ajustar el ancho",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -1012,7 +1012,6 @@
   "No AI sources configured": "Aucune source IA configurée",
   "No answer was produced.": "Aucune réponse n’a été produite.",
   "No apps found": "Aucune application trouvée",
-  "No apps in this collection yet": "Aucune app dans cette collection",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "Aucune vérification automatique des mises à jour. Utilisez Vérifier les mises à jour pour mettre à jour à la demande.",
   "No Bot instances configured. Click the button below to add one.": "Aucune instance de Bot configurée. Cliquez sur le bouton ci-dessous pour en ajouter une.",
   "No changes": "Aucune modification",

--- a/src/renderer/i18n/locales/fr.json
+++ b/src/renderer/i18n/locales/fr.json
@@ -568,8 +568,6 @@
   "Download": "Télécharger",
   "Download and install manually": "Télécharger et installer manuellement",
   "Downloading {{version}}… {{percent}}%": "Téléchargement de {{version}}… {{percent}}%",
-  "Downloading in the background…": "Téléchargement en arrière-plan…",
-  "Downloading… {{percent}}%": "Téléchargement… {{percent}}%",
   "Draft a reusable weekly report template": "Rédiger un modèle de rapport hebdomadaire réutilisable",
   "Drag to resize": "Glisser pour redimensionner",
   "Drag to resize width": "Glisser pour redimensionner la largeur",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -528,8 +528,6 @@
   "Download": "ダウンロード",
   "Download and install manually": "手動でダウンロードしてインストール",
   "Downloading {{version}}… {{percent}}%": "{{version}} をダウンロードしています… {{percent}}%",
-  "Downloading in the background…": "バックグラウンドでダウンロードしています…",
-  "Downloading… {{percent}}%": "ダウンロードしています… {{percent}}%",
   "Draft a reusable weekly report template": "再利用可能な週次レポートテンプレートを作成します",
   "Drag to resize": "ドラッグしてサイズ変更",
   "Drag to resize width": "ドラッグして幅を変更",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -961,7 +961,6 @@
   "No AI sources configured": "AIソースが設定されていません",
   "No answer was produced.": "回答が生成されませんでした。",
   "No apps found": "アプリが見つかりません",
-  "No apps in this collection yet": "このコレクションにはまだアプリがありません",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "自動アップグレードチェックはありません。「アップグレードを確認」を使用してオンデマンドで更新してください。",
   "No Bot instances configured. Click the button below to add one.": "Botインスタンスが設定されていません。下のボタンをクリックして追加してください。",
   "No changes": "変更なし",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -961,7 +961,6 @@
   "No AI sources configured": "未配置AI来源",
   "No answer was produced.": "没有生成回答。",
   "No apps found": "未找到应用",
-  "No apps in this collection yet": "该专题暂无应用",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "不自动检查升级。使用「检查升级」按需更新。",
   "No Bot instances configured. Click the button below to add one.": "未配置机器人实例。点击下方按钮添加一个。",
   "No changes": "无更改",

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -528,8 +528,6 @@
   "Download": "下载",
   "Download and install manually": "手动下载并安装",
   "Downloading {{version}}… {{percent}}%": "正在下载 {{version}}… {{percent}}%",
-  "Downloading in the background…": "正在后台下载…",
-  "Downloading… {{percent}}%": "正在下载… {{percent}}%",
   "Draft a reusable weekly report template": "草拟一个可复用的周报模板",
   "Drag to resize": "拖动调整大小",
   "Drag to resize width": "拖动调整宽度",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -961,7 +961,6 @@
   "No AI sources configured": "尚未設定 AI 來源",
   "No answer was produced.": "沒有產生回答。",
   "No apps found": "找不到應用程式",
-  "No apps in this collection yet": "該專題暫無應用",
   "No automatic upgrade checks. Use Check for upgrades to update on demand.": "無自動更新檢查。請使用「檢查更新」以按需更新。",
   "No Bot instances configured. Click the button below to add one.": "未設定任何 Bot 執行個體。請點擊下方按鈕新增。",
   "No changes": "無變更",

--- a/src/renderer/i18n/locales/zh-TW.json
+++ b/src/renderer/i18n/locales/zh-TW.json
@@ -528,8 +528,6 @@
   "Download": "下載",
   "Download and install manually": "手動下載並安裝",
   "Downloading {{version}}… {{percent}}%": "正在下載 {{version}}… {{percent}}%",
-  "Downloading in the background…": "正在背景下載…",
-  "Downloading… {{percent}}%": "正在下載… {{percent}}%",
   "Draft a reusable weekly report template": "草擬一個可重複使用的週報範本",
   "Drag to resize": "拖曳以調整大小",
   "Drag to resize width": "拖曳以調整寬度",

--- a/src/renderer/stores/apps-page.store.ts
+++ b/src/renderer/stores/apps-page.store.ts
@@ -49,9 +49,6 @@ function storeListCacheKey(q: { category?: string; type?: string; locale?: strin
   return `${q.locale ?? ''}|${q.type ?? ''}|${q.category ?? ''}`
 }
 
-/** The slug already counted for the selection currently on screen. */
-let reportedDetailSlug: string | null = null
-
 /**
  * A detail fetch outlives the selection that started it: without invalidating
  * it, a slow response lands on a state the user already left, repainting the
@@ -59,20 +56,14 @@ let reportedDetailSlug: string | null = null
  */
 function abandonStoreDetail(): void {
   storeDetailRequestSeq++
-  reportedDetailSlug = null
 }
 
 /**
- * One opened detail, one event. Reported from the action rather than the view
- * because every entry point routes through here, while the view remounts on
- * things that are not an open — leaving the store tab with a detail on screen
- * and coming back used to count a second time. Keyed on the slug rather than on
- * the caller's intent so that a Retry counts the load it finally succeeds at,
- * having counted nothing for the attempt that failed.
+ * Reported from the action rather than from the detail view: every entry point
+ * routes through here, while the view also remounts on things that are not an
+ * open, such as leaving the store tab with a detail on screen and coming back.
  */
 function reportDetailView(detail: StoreAppDetail, availableUpdates: UpdateInfo[]): void {
-  if (reportedDetailSlug === detail.entry.slug) return
-  reportedDetailSlug = detail.entry.slug
   const installedApp = findInstalledApp(detail.entry, detail.registryId, useAppsStore.getState().apps)
   const updateInfo = findEntryUpdate(installedApp, availableUpdates)
   void api.trackEvent('store.detail.view', {
@@ -553,7 +544,9 @@ export const useAppsPageStore = create<AppsPageState>()(
       console.error('[AppsPageStore] selectStoreApp error:', err)
       set({ storeDetailError: 'Failed to load app detail' })
     } finally {
-      set({ storeDetailLoading: false })
+      // A superseded response must not clear the flag its successor is still
+      // waiting on, or the detail renders as not-found until that one lands.
+      if (requestId === storeDetailRequestSeq) set({ storeDetailLoading: false })
     }
   },
 

--- a/src/renderer/stores/apps-page.store.ts
+++ b/src/renderer/stores/apps-page.store.ts
@@ -16,6 +16,8 @@ import { persist } from 'zustand/middleware'
 import { api } from '../api'
 import { getCurrentLanguage } from '../i18n'
 import { categoryTaxonomyResource, discoverPageResource } from '../lib/store-resources'
+import { findInstalledApp, findEntryUpdate } from '../utils/store-install-state'
+import { useAppsStore } from './apps.store'
 import type { RegistryEntry, StoreAppDetail, UpdateInfo, StoreQuery, StoreQueryResponse, StoreInstallProgress } from '../../shared/store/store-types'
 import type { AppType } from '../../shared/apps/spec-types'
 import type { ImSessionRecord } from '../../shared/types/im-channel'
@@ -45,6 +47,22 @@ const storeListCache = new Map<string, { items: RegistryEntry[]; page: number; h
 
 function storeListCacheKey(q: { category?: string; type?: string; locale?: string }): string {
   return `${q.locale ?? ''}|${q.type ?? ''}|${q.category ?? ''}`
+}
+
+/**
+ * One opened detail, one event. Reported from the action rather than the view
+ * because every entry point routes through here, while the view remounts on
+ * things that are not an open — leaving the store tab with a detail on screen
+ * and coming back used to count a second time.
+ */
+function reportDetailView(detail: StoreAppDetail, availableUpdates: UpdateInfo[]): void {
+  const installedApp = findInstalledApp(detail.entry, detail.registryId, useAppsStore.getState().apps)
+  const updateInfo = findEntryUpdate(installedApp, availableUpdates)
+  void api.trackEvent('store.detail.view', {
+    appId: detail.entry.slug,
+    appType: detail.entry.type,
+    installedState: updateInfo ? 'update' : installedApp ? 'installed' : 'new',
+  })
 }
 
 // ============================================
@@ -171,7 +189,12 @@ interface AppsPageState {
    * never forget the reload step.
    */
   openMarketplaceFilteredBy: (type: AppType | null) => Promise<void>
-  selectStoreApp: (slug: string, autoInstall?: boolean) => Promise<void>
+  /**
+   * `intent` separates opening a detail from re-reading one already open: a
+   * failed load's Retry re-runs this, and counting that as a second view would
+   * inflate the funnel with the user's recovery from an error.
+   */
+  selectStoreApp: (slug: string, autoInstall?: boolean, intent?: 'open' | 'reload') => Promise<void>
   clearStoreSelection: () => void
   /** Consume the "open install dialog on arrival" intent set by a card's install button. */
   consumeStoreAutoInstall: () => boolean
@@ -495,7 +518,7 @@ export const useAppsPageStore = create<AppsPageState>()(
     await get().loadStoreApps()
   },
 
-  selectStoreApp: async (slug, autoInstall = false) => {
+  selectStoreApp: async (slug, autoInstall = false, intent = 'open') => {
     const requestId = ++storeDetailRequestSeq
     set({ storeSelectedSlug: slug, storeAutoInstall: autoInstall, storeDetailLoading: true, storeSelectedDetail: null, storeDetailError: null })
     try {
@@ -503,7 +526,9 @@ export const useAppsPageStore = create<AppsPageState>()(
       if (requestId !== storeDetailRequestSeq) return
 
       if (res.success && res.data) {
-        set({ storeSelectedDetail: res.data as StoreAppDetail })
+        const detail = res.data as StoreAppDetail
+        set({ storeSelectedDetail: detail })
+        if (intent === 'open') reportDetailView(detail, get().availableUpdates)
       } else {
         console.error('[AppsPageStore] selectStoreApp failed:', res.error)
         set({ storeDetailError: (res.error as string) || 'Failed to load app detail' })

--- a/src/renderer/stores/apps-page.store.ts
+++ b/src/renderer/stores/apps-page.store.ts
@@ -49,13 +49,30 @@ function storeListCacheKey(q: { category?: string; type?: string; locale?: strin
   return `${q.locale ?? ''}|${q.type ?? ''}|${q.category ?? ''}`
 }
 
+/** The slug already counted for the selection currently on screen. */
+let reportedDetailSlug: string | null = null
+
+/**
+ * A detail fetch outlives the selection that started it: without invalidating
+ * it, a slow response lands on a state the user already left, repainting the
+ * detail they backed out of and counting a view for it.
+ */
+function abandonStoreDetail(): void {
+  storeDetailRequestSeq++
+  reportedDetailSlug = null
+}
+
 /**
  * One opened detail, one event. Reported from the action rather than the view
  * because every entry point routes through here, while the view remounts on
  * things that are not an open — leaving the store tab with a detail on screen
- * and coming back used to count a second time.
+ * and coming back used to count a second time. Keyed on the slug rather than on
+ * the caller's intent so that a Retry counts the load it finally succeeds at,
+ * having counted nothing for the attempt that failed.
  */
 function reportDetailView(detail: StoreAppDetail, availableUpdates: UpdateInfo[]): void {
+  if (reportedDetailSlug === detail.entry.slug) return
+  reportedDetailSlug = detail.entry.slug
   const installedApp = findInstalledApp(detail.entry, detail.registryId, useAppsStore.getState().apps)
   const updateInfo = findEntryUpdate(installedApp, availableUpdates)
   void api.trackEvent('store.detail.view', {
@@ -189,12 +206,7 @@ interface AppsPageState {
    * never forget the reload step.
    */
   openMarketplaceFilteredBy: (type: AppType | null) => Promise<void>
-  /**
-   * `intent` separates opening a detail from re-reading one already open: a
-   * failed load's Retry re-runs this, and counting that as a second view would
-   * inflate the funnel with the user's recovery from an error.
-   */
-  selectStoreApp: (slug: string, autoInstall?: boolean, intent?: 'open' | 'reload') => Promise<void>
+  selectStoreApp: (slug: string, autoInstall?: boolean) => Promise<void>
   clearStoreSelection: () => void
   /** Consume the "open install dialog on arrival" intent set by a card's install button. */
   consumeStoreAutoInstall: () => boolean
@@ -301,30 +313,33 @@ export const useAppsPageStore = create<AppsPageState>()(
     }
   },
 
-  reset: () => set({
-    selectedAppId: null,
-    detailView: null,
-    initialAppId: null,
-    showInstallDialog: false,
-    currentTab: 'my-digital-humans',
-    imPanelOpen: true,
-    selectedImSession: null,
-    imSessions: [],
-    imSessionsAppId: null,
-    storeApps: [],
-    storeLoading: false,
-    storeError: null,
-    storeSearchQuery: '',
-    storeCategory: null,
-    storeTypeFilter: null,
-    storePage: 1,
-    storeHasMore: false,
-    storeSelectedSlug: null,
-    storeSelectedDetail: null,
-    storeDetailLoading: false,
-    storeDetailError: null,
-    availableUpdates: [],
-  }),
+  reset: () => {
+    abandonStoreDetail()
+    set({
+      selectedAppId: null,
+      detailView: null,
+      initialAppId: null,
+      showInstallDialog: false,
+      currentTab: 'my-digital-humans',
+      imPanelOpen: true,
+      selectedImSession: null,
+      imSessions: [],
+      imSessionsAppId: null,
+      storeApps: [],
+      storeLoading: false,
+      storeError: null,
+      storeSearchQuery: '',
+      storeCategory: null,
+      storeTypeFilter: null,
+      storePage: 1,
+      storeHasMore: false,
+      storeSelectedSlug: null,
+      storeSelectedDetail: null,
+      storeDetailLoading: false,
+      storeDetailError: null,
+      availableUpdates: [],
+    })
+  },
 
   // ── Store Actions ──────────────────────────
 
@@ -518,7 +533,7 @@ export const useAppsPageStore = create<AppsPageState>()(
     await get().loadStoreApps()
   },
 
-  selectStoreApp: async (slug, autoInstall = false, intent = 'open') => {
+  selectStoreApp: async (slug, autoInstall = false) => {
     const requestId = ++storeDetailRequestSeq
     set({ storeSelectedSlug: slug, storeAutoInstall: autoInstall, storeDetailLoading: true, storeSelectedDetail: null, storeDetailError: null })
     try {
@@ -528,7 +543,7 @@ export const useAppsPageStore = create<AppsPageState>()(
       if (res.success && res.data) {
         const detail = res.data as StoreAppDetail
         set({ storeSelectedDetail: detail })
-        if (intent === 'open') reportDetailView(detail, get().availableUpdates)
+        reportDetailView(detail, get().availableUpdates)
       } else {
         console.error('[AppsPageStore] selectStoreApp failed:', res.error)
         set({ storeDetailError: (res.error as string) || 'Failed to load app detail' })
@@ -542,14 +557,17 @@ export const useAppsPageStore = create<AppsPageState>()(
     }
   },
 
-  clearStoreSelection: () => set({
-    storeSelectedSlug: null,
-    storeAutoInstall: false,
-    storeSelectedDetail: null,
-    storeDetailLoading: false,
-    storeDetailError: null,
-    storeError: null,
-  }),
+  clearStoreSelection: () => {
+    abandonStoreDetail()
+    set({
+      storeSelectedSlug: null,
+      storeAutoInstall: false,
+      storeSelectedDetail: null,
+      storeDetailLoading: false,
+      storeDetailError: null,
+      storeError: null,
+    })
+  },
 
   consumeStoreAutoInstall: () => {
     if (!get().storeAutoInstall) return false
@@ -560,6 +578,7 @@ export const useAppsPageStore = create<AppsPageState>()(
   openStorePublish: (type, appId) => {
     // Surface the store tab's header (which owns the publish dialog): leave any
     // detail/mine sub-view so StoreHeader renders and can consume the intent.
+    abandonStoreDetail()
     set({
       currentTab: 'store',
       storeMineOpen: false,

--- a/src/renderer/stores/notification.store.ts
+++ b/src/renderer/stores/notification.store.ts
@@ -16,12 +16,13 @@
  */
 
 import { create } from 'zustand'
+import type { ToastVariant, ToastBodyFormat } from '../../shared/types/notification'
 
 // ============================================
 // Types
 // ============================================
 
-export type ToastVariant = 'default' | 'success' | 'warning' | 'error'
+export type { ToastVariant, ToastBodyFormat }
 
 export interface ToastAction {
   label: string
@@ -35,6 +36,12 @@ export interface ToastItem {
   title: string
   /** Notification body text */
   body?: string
+  /**
+   * How to render `body`. Defaults to plain text.
+   * 'markdown' routes through RichText — use it for server-authored copy
+   * (release notes, announcements) that needs lists or inline links.
+   */
+  bodyFormat?: ToastBodyFormat
   /** Visual variant — controls icon and accent color */
   variant: ToastVariant
   /** Primary action button (e.g. "Restart now", "View") */

--- a/src/shared/store/store-types.ts
+++ b/src/shared/store/store-types.ts
@@ -436,7 +436,7 @@ export interface ResolvedDiscoverNode {
   /** Resolved entries for a section, or the first catalog page. */
   entries?: RegistryEntry[]
   /** Only for the `collections` layout. */
-  collections?: StoreCollection[]
+  collections?: ResolvedCollection[]
   /** Only for `catalog`: whether further pages exist behind the browse query. */
   hasMore?: boolean
 }
@@ -477,6 +477,21 @@ export interface StoreCollection {
   description: string
   /** Ordered member app slugs. */
   memberSlugs: string[]
+}
+
+/**
+ * A collection whose members have been looked up in the index. Resolution
+ * belongs to the main process, which holds the full mirror: the renderer only
+ * has a page of the catalog, so resolving there drops every member outside it.
+ *
+ * `memberSlugs` is dropped rather than carried alongside `entries`, so a
+ * consumer has no second, resolvable-looking representation of membership to
+ * reach for — which is exactly how the members ended up being resolved against
+ * the browse list before.
+ */
+export interface ResolvedCollection extends Omit<StoreCollection, 'memberSlugs'> {
+  /** Members present in the index, in the curated order. */
+  entries: RegistryEntry[]
 }
 
 // ============================================

--- a/src/shared/types/announcement.ts
+++ b/src/shared/types/announcement.ts
@@ -1,0 +1,49 @@
+/**
+ * Announcement feed contract.
+ *
+ * This is the wire format of the JSON document served at
+ * `product.json > announcementsUrl`. It is the stable half of the feature:
+ * the client surface may change (today a toast, later a message centre) but a
+ * published feed must keep working, so treat every field here as public API.
+ *
+ * Authoring notes for whoever maintains the feed:
+ * - `id` must be unique and stable. It is the dedup key — reusing an id for
+ *   different content means the new content is never shown.
+ * - `expiresAt` is effectively mandatory in practice: without it an entry is
+ *   shown to every new install forever. Emptying the feed file retracts
+ *   everything.
+ */
+
+import type { ToastVariant, ToastBodyFormat, ToastLinkAction } from './notification'
+
+export interface Announcement {
+  /** Stable unique id. Dedup key — never reuse across different content. */
+  id: string
+  title: string
+  body?: string
+  /** Defaults to 'text'. Raw HTML is never rendered — see RichText. */
+  bodyFormat?: ToastBodyFormat
+  /** Visual accent. Defaults to 'default'. */
+  severity?: ToastVariant
+  /** ISO date-time. Entry stays hidden before this instant. */
+  startsAt?: string
+  /** ISO date-time. Entry stops showing after this instant. */
+  expiresAt?: string
+  /** Optional call to action. Only http/https URLs are honoured. */
+  action?: ToastLinkAction
+  /** Inclusive lower bound on the app version that should see this entry. */
+  minVersion?: string
+  /** Inclusive upper bound on the app version that should see this entry. */
+  maxVersion?: string
+}
+
+/**
+ * Feed document root.
+ *
+ * A bare array is also accepted by the client so a minimal feed can be a
+ * plain JSON list, but new feeds should use this object form — it leaves room
+ * for feed-level metadata without another format break.
+ */
+export interface AnnouncementFeed {
+  announcements: Announcement[]
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -63,6 +63,12 @@ export * from './artifact'
 // Notification channel types (shared between main process and renderer)
 export * from './notification-channels'
 
+// In-app toast contract (main -> renderer, incl. remote/mobile over WebSocket)
+export * from './notification'
+
+// Announcement feed contract (remote JSON -> main)
+export * from './announcement'
+
 // Inbound message types (IM channel adapter boundary types)
 export * from './inbound-message'
 

--- a/src/shared/types/notification.ts
+++ b/src/shared/types/notification.ts
@@ -1,0 +1,49 @@
+/**
+ * In-app toast notification contract.
+ *
+ * Shared because the same shape is produced by the main process
+ * (`services/notification.service.ts`) and consumed by the renderer store —
+ * a re-declaration on either side would silently drop fields in transit.
+ *
+ * Everything here must stay JSON-serializable: toasts reach remote and mobile
+ * clients over WebSocket, not just the Electron renderer.
+ */
+
+export type ToastVariant = 'default' | 'success' | 'warning' | 'error'
+
+/**
+ * How `body` should be rendered.
+ *
+ * - 'text'     — plain text, whitespace preserved (default; every legacy caller)
+ * - 'markdown' — restricted markdown: lists, emphasis, inline links. Raw HTML is
+ *                never rendered and link protocols are filtered, because this
+ *                content can originate from a remote server (release notes,
+ *                announcements). See `components/ui/RichText.tsx`.
+ */
+export type ToastBodyFormat = 'text' | 'markdown'
+
+/**
+ * Link action for toasts that cross a process boundary.
+ *
+ * Renderer-local toasts use a callback instead; a callback cannot survive IPC,
+ * so main-originated actions declare a URL and the renderer binds the handler.
+ */
+export interface ToastLinkAction {
+  label: string
+  url: string
+}
+
+/** Wire shape of the `notification:toast` event (main → renderer). */
+export interface ToastPayload {
+  /** Stable id — repeat sends with the same id replace rather than stack. */
+  id?: string
+  title: string
+  body?: string
+  bodyFormat?: ToastBodyFormat
+  variant?: ToastVariant
+  /** Auto-dismiss in ms. 0 = sticky (manual dismiss only). */
+  duration?: number
+  /** Deep-links the toast to an installed App's activity thread. */
+  appId?: string
+  action?: ToastLinkAction
+}

--- a/tests/unit/renderer/store-detail-view-telemetry.test.ts
+++ b/tests/unit/renderer/store-detail-view-telemetry.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The `store.detail.view` side of the store funnel: one event per detail the
+ * user actually reaches, counted from the action every entry point routes
+ * through.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const trackEvent = vi.fn()
+const storeGetAppDetail = vi.fn()
+
+vi.mock('../../../src/renderer/api', () => ({
+  api: {
+    trackEvent,
+    storeGetAppDetail: (slug: string) => storeGetAppDetail(slug),
+    storeList: vi.fn(),
+    storeInstall: vi.fn(),
+    imSessionsList: vi.fn(),
+  },
+}))
+
+vi.mock('../../../src/renderer/i18n', () => ({ getCurrentLanguage: () => 'en' }))
+
+vi.mock('../../../src/renderer/lib/store-resources', () => ({
+  categoryTaxonomyResource: { invalidate: vi.fn(), get: vi.fn() },
+  discoverPageResource: { invalidate: vi.fn(), get: vi.fn() },
+}))
+
+vi.mock('../../../src/renderer/stores/apps.store', () => ({
+  useAppsStore: { getState: () => ({ apps: [] }) },
+}))
+
+const persisted = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => persisted.get(key) ?? null,
+  setItem: (key: string, value: string) => { persisted.set(key, value) },
+  removeItem: (key: string) => { persisted.delete(key) },
+})
+
+const { useAppsPageStore } = await import('../../../src/renderer/stores/apps-page.store')
+
+function detailOf(slug: string) {
+  return { success: true, data: { entry: { slug, type: 'skill' }, registryId: 'halo' } }
+}
+
+function viewedSlugs(): string[] {
+  return trackEvent.mock.calls
+    .filter(([event]) => event === 'store.detail.view')
+    .map(([, props]) => (props as { appId: string }).appId)
+}
+
+describe('store detail view telemetry', () => {
+  beforeEach(() => {
+    trackEvent.mockClear()
+    storeGetAppDetail.mockReset()
+    useAppsPageStore.getState().clearStoreSelection()
+    trackEvent.mockClear()
+  })
+
+  it('counts the load a retry succeeds at, having counted nothing for the failure', async () => {
+    storeGetAppDetail
+      .mockResolvedValueOnce({ success: false, error: 'offline' })
+      .mockResolvedValueOnce(detailOf('alpha'))
+
+    await useAppsPageStore.getState().selectStoreApp('alpha')
+    expect(viewedSlugs()).toEqual([])
+
+    await useAppsPageStore.getState().selectStoreApp('alpha')
+    expect(viewedSlugs()).toEqual(['alpha'])
+  })
+
+  it('counts one view when an already-loaded detail is re-read', async () => {
+    storeGetAppDetail.mockResolvedValue(detailOf('alpha'))
+
+    await useAppsPageStore.getState().selectStoreApp('alpha')
+    await useAppsPageStore.getState().selectStoreApp('alpha')
+
+    expect(viewedSlugs()).toEqual(['alpha'])
+  })
+
+  it('counts again when the app is reopened after leaving the detail', async () => {
+    storeGetAppDetail.mockResolvedValue(detailOf('alpha'))
+
+    await useAppsPageStore.getState().selectStoreApp('alpha')
+    useAppsPageStore.getState().clearStoreSelection()
+    await useAppsPageStore.getState().selectStoreApp('alpha')
+
+    expect(viewedSlugs()).toEqual(['alpha', 'alpha'])
+  })
+
+  it('drops a response that arrives after the user left the detail', async () => {
+    let release: (value: unknown) => void = () => {}
+    storeGetAppDetail.mockReturnValueOnce(new Promise(resolve => { release = resolve }))
+
+    const pending = useAppsPageStore.getState().selectStoreApp('alpha')
+    useAppsPageStore.getState().clearStoreSelection()
+    release(detailOf('alpha'))
+    await pending
+
+    expect(viewedSlugs()).toEqual([])
+    expect(useAppsPageStore.getState().storeSelectedDetail).toBeNull()
+  })
+})

--- a/tests/unit/renderer/store-detail-view-telemetry.test.ts
+++ b/tests/unit/renderer/store-detail-view-telemetry.test.ts
@@ -13,9 +13,6 @@ vi.mock('../../../src/renderer/api', () => ({
   api: {
     trackEvent,
     storeGetAppDetail: (slug: string) => storeGetAppDetail(slug),
-    storeList: vi.fn(),
-    storeInstall: vi.fn(),
-    imSessionsList: vi.fn(),
   },
 }))
 
@@ -69,15 +66,6 @@ describe('store detail view telemetry', () => {
     expect(viewedSlugs()).toEqual(['alpha'])
   })
 
-  it('counts one view when an already-loaded detail is re-read', async () => {
-    storeGetAppDetail.mockResolvedValue(detailOf('alpha'))
-
-    await useAppsPageStore.getState().selectStoreApp('alpha')
-    await useAppsPageStore.getState().selectStoreApp('alpha')
-
-    expect(viewedSlugs()).toEqual(['alpha'])
-  })
-
   it('counts again when the app is reopened after leaving the detail', async () => {
     storeGetAppDetail.mockResolvedValue(detailOf('alpha'))
 
@@ -99,5 +87,20 @@ describe('store detail view telemetry', () => {
 
     expect(viewedSlugs()).toEqual([])
     expect(useAppsPageStore.getState().storeSelectedDetail).toBeNull()
+  })
+
+  it('leaves the loading flag to the newer request when a superseded one returns', async () => {
+    let releaseFirst: (value: unknown) => void = () => {}
+    storeGetAppDetail
+      .mockReturnValueOnce(new Promise(resolve => { releaseFirst = resolve }))
+      .mockReturnValueOnce(new Promise(() => {}))
+
+    const superseded = useAppsPageStore.getState().selectStoreApp('alpha')
+    void useAppsPageStore.getState().selectStoreApp('beta')
+    releaseFirst(detailOf('alpha'))
+    await superseded
+
+    expect(viewedSlugs()).toEqual([])
+    expect(useAppsPageStore.getState().storeDetailLoading).toBe(true)
   })
 })

--- a/tests/unit/services/announcement.service.test.ts
+++ b/tests/unit/services/announcement.service.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Announcement service tests
+ *
+ * The feed is server-authored and reaches every user, so the failure modes that
+ * matter are the quiet ones: an entry that repeats forever because dedup broke,
+ * a retracted entry that keeps showing because the schedule window is ignored,
+ * or a hostile URL surviving into a clickable button. Each is pinned here
+ * because none of them would be obvious at runtime.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Announcement } from '../../../src/shared/types/announcement'
+
+const FEED_URL = 'http://feed.internal/announcements.json'
+
+let feedUrl: string | undefined = FEED_URL
+let appVersion = '2.1.14'
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => appVersion,
+    getPath: () => '/tmp/halo-test',
+  },
+}))
+
+vi.mock('../../../src/main/foundation/product-config', () => ({
+  getAnnouncementsUrl: () => feedUrl,
+}))
+
+/** Mirrors pushToast's contract: true when a client actually received it. */
+const pushToast = vi.fn<(payload: unknown) => boolean>(() => true)
+vi.mock('../../../src/main/services/notification.service', () => ({
+  pushToast: (payload: unknown) => pushToast(payload),
+}))
+
+const proxyFetch = vi.fn()
+vi.mock('../../../src/main/services/proxy-fetch', () => ({
+  proxyFetch: (...args: unknown[]) => proxyFetch(...args),
+}))
+
+/** In-memory stand-in for the dedup state file. */
+let diskFile: string | null = null
+vi.mock('fs', () => ({
+  existsSync: () => diskFile !== null,
+  readFileSync: () => diskFile ?? '',
+  writeFileSync: (_path: string, data: string) => { diskFile = data },
+  mkdirSync: () => undefined,
+}))
+
+function feedResponse(entries: unknown, init?: { status?: number; etag?: string }) {
+  const body = JSON.stringify(entries)
+  return {
+    ok: (init?.status ?? 200) < 400,
+    status: init?.status ?? 200,
+    statusText: 'OK',
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'etag' ? init?.etag ?? null : null),
+    },
+    text: async () => body,
+  }
+}
+
+async function checkNow() {
+  const module = await import('../../../src/main/services/announcement.service')
+  return module.checkAnnouncementsNow()
+}
+
+/** Titles of every announcement pushed to the renderer so far. */
+function shownTitles(): string[] {
+  return pushToast.mock.calls.map(([payload]) => (payload as { title: string }).title)
+}
+
+const BASIC: Announcement = { id: 'a1', title: 'Scheduled maintenance' }
+
+describe('announcement.service', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    pushToast.mockClear()
+    pushToast.mockReturnValue(true)
+    proxyFetch.mockReset()
+    diskFile = null
+    feedUrl = FEED_URL
+    appVersion = '2.1.14'
+  })
+
+  it('does nothing when the build has no feed configured', async () => {
+    feedUrl = undefined
+
+    expect(await checkNow()).toBe(0)
+    expect(proxyFetch).not.toHaveBeenCalled()
+  })
+
+  it('shows a due announcement', async () => {
+    proxyFetch.mockResolvedValue(feedResponse({ announcements: [BASIC] }))
+
+    expect(await checkNow()).toBe(1)
+    expect(shownTitles()).toEqual(['Scheduled maintenance'])
+  })
+
+  it('accepts a bare array feed', async () => {
+    proxyFetch.mockResolvedValue(feedResponse([BASIC]))
+
+    expect(await checkNow()).toBe(1)
+  })
+
+  it('never shows the same id twice, even across restarts', async () => {
+    proxyFetch.mockResolvedValue(feedResponse({ announcements: [BASIC] }))
+    await checkNow()
+
+    // Fresh module instance = new process; only the state file carries over.
+    vi.resetModules()
+    expect(await checkNow()).toBe(0)
+    expect(pushToast).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries an announcement that reached no client', async () => {
+    // Window closed with no remote client attached: recording it as shown would
+    // retire the entry without anyone ever reading it.
+    pushToast.mockReturnValue(false)
+    proxyFetch.mockResolvedValue(feedResponse({ announcements: [BASIC] }))
+
+    expect(await checkNow()).toBe(0)
+    expect(diskFile).toBeNull()
+
+    pushToast.mockReturnValue(true)
+    vi.resetModules()
+    expect(await checkNow()).toBe(1)
+  })
+
+  it('honours the schedule window', async () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString()
+    const past = new Date(Date.now() - 86_400_000).toISOString()
+
+    proxyFetch.mockResolvedValue(feedResponse({
+      announcements: [
+        { id: 'not-yet', title: 'Future', startsAt: future },
+        { id: 'expired', title: 'Expired', expiresAt: past },
+        { id: 'live', title: 'Live', startsAt: past, expiresAt: future },
+      ],
+    }))
+
+    expect(await checkNow()).toBe(1)
+    expect(shownTitles()).toEqual(['Live'])
+  })
+
+  it('targets a version range, ignoring pre-release suffixes', async () => {
+    appVersion = '2.1.13-rc.2'
+    proxyFetch.mockResolvedValue(feedResponse({
+      announcements: [
+        { id: 'old-only', title: 'Please upgrade', maxVersion: '2.1.13' },
+        { id: 'new-only', title: 'New feature tour', minVersion: '2.2.0' },
+      ],
+    }))
+
+    expect(await checkNow()).toBe(1)
+    expect(shownTitles()).toEqual(['Please upgrade'])
+  })
+
+  it('drops an action whose URL is not http(s)', async () => {
+    proxyFetch.mockResolvedValue(feedResponse({
+      announcements: [
+        { id: 'safe', title: 'Safe', action: { label: 'Docs', url: 'https://example.com' } },
+        { id: 'unsafe', title: 'Unsafe', action: { label: 'Run', url: 'javascript:alert(1)' } },
+        { id: 'local', title: 'Local', action: { label: 'Open', url: 'file:///etc/passwd' } },
+      ],
+    }))
+
+    await checkNow()
+
+    const actions = pushToast.mock.calls.map(([payload]) => (payload as { action?: unknown }).action)
+    expect(actions).toEqual([
+      { label: 'Docs', url: 'https://example.com' },
+      undefined,
+      undefined,
+    ])
+  })
+
+  it('skips malformed entries without dropping the rest of the feed', async () => {
+    proxyFetch.mockResolvedValue(feedResponse({
+      announcements: [
+        { title: 'No id' },
+        { id: 'no-title' },
+        null,
+        'not an object',
+        BASIC,
+      ],
+    }))
+
+    expect(await checkNow()).toBe(1)
+    expect(shownTitles()).toEqual(['Scheduled maintenance'])
+  })
+
+  it('treats an unchanged feed (304) as a no-op', async () => {
+    proxyFetch.mockResolvedValue(feedResponse({ announcements: [BASIC] }, { status: 304 }))
+
+    expect(await checkNow()).toBe(0)
+    expect(pushToast).not.toHaveBeenCalled()
+  })
+
+  it('survives a feed host that is down', async () => {
+    proxyFetch.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    await expect(checkNow()).resolves.toBe(0)
+    expect(pushToast).not.toHaveBeenCalled()
+  })
+
+  it('survives a feed that is not valid JSON', async () => {
+    proxyFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => '<html>404</html>',
+    })
+
+    await expect(checkNow()).resolves.toBe(0)
+    expect(pushToast).not.toHaveBeenCalled()
+  })
+
+  it('forwards the body format so server copy can use markdown', async () => {
+    proxyFetch.mockResolvedValue(feedResponse({
+      announcements: [{ id: 'rich', title: 'Release', body: '- one\n- two', bodyFormat: 'markdown' }],
+    }))
+
+    await checkNow()
+
+    expect(pushToast).toHaveBeenCalledWith(expect.objectContaining({
+      bodyFormat: 'markdown',
+      body: '- one\n- two',
+    }))
+  })
+})

--- a/tests/unit/store/discover-page.test.ts
+++ b/tests/unit/store/discover-page.test.ts
@@ -137,11 +137,52 @@ describe('discover-page', () => {
 
     const withSection = await load(
       { version: 1, nodes: [{ type: 'section', layout: 'collections' }] },
-      { collections: [{ id: 'c', label: 'l', name: 'n', description: '', memberSlugs: [] }] },
+      {
+        byType: { skill: [entry('c1', 'skill')] },
+        collections: [{ id: 'c', label: 'l', name: 'n', description: '', memberSlugs: ['c1'] }],
+      },
     )
     const result = await withSection.getDiscoverPage('en', 30)
     expect(withSection.fetchCollections).toHaveBeenCalled()
     expect(result.nodes[0].collections).toHaveLength(1)
+  })
+
+  it('resolves every collection member from the index, not from the catalog page', async () => {
+    const members = Array.from({ length: 18 }, (_, i) => entry(`m${i}`, 'skill'))
+    const { getDiscoverPage } = await load(
+      { version: 1, nodes: [{ type: 'section', layout: 'collections' }] },
+      {
+        byType: { skill: members },
+        // The catalog page holds a fraction of them: resolving there would cap
+        // the collection at whatever fits.
+        catalog: { items: members.slice(0, 6), hasMore: true },
+        collections: [{
+          id: 'c', label: 'l', name: 'n', description: '',
+          memberSlugs: members.map(m => m.slug),
+        }],
+      },
+    )
+
+    const result = await getDiscoverPage('en', 30)
+
+    expect(result.nodes[0].collections?.[0].entries).toHaveLength(18)
+  })
+
+  it('drops collection members the index does not carry', async () => {
+    const { getDiscoverPage } = await load(
+      { version: 1, nodes: [{ type: 'section', layout: 'collections' }] },
+      {
+        byType: { skill: [entry('kept', 'skill')] },
+        collections: [{
+          id: 'c', label: 'l', name: 'n', description: '',
+          memberSlugs: ['kept', 'unpublished'],
+        }],
+      },
+    )
+
+    const result = await getDiscoverPage('en', 30)
+
+    expect(result.nodes[0].collections?.[0].entries.map(e => e.slug)).toEqual(['kept'])
   })
 
   it('keeps the page alive when one type\'s index query fails', async () => {


### PR DESCRIPTION
## Summary
This branch is 2 business commits ahead of origin/feat/new-market (plus 2 sync commits from origin/main).

### 1. Scene collections only rendered their first 6 members
`StoreDiscover` built its slug→entry map from `storeApps` — the paginated browse list, 30 items on its first page — and used it to resolve collection members. Any member outside that page resolved to `undefined` and was silently filtered out. A collection configured with 18 members showed 6 in the client dialog, while the card badge read the unfiltered `memberSlugs.length`, so the same screen displayed both 18 and 6.

Membership now resolves in the main process against the **full index**, reusing the existing `resolveSection` rather than duplicating slug resolution. The renderer consumes `ResolvedCollection.entries` directly. `ResolvedCollection extends Omit<StoreCollection, 'memberSlugs'>` makes it structurally impossible for the renderer to receive unresolved slugs again. Missing members are dropped and logged with a count.

### 2. Store funnel reported `card.click` (109) < `detail.view` (202)
The two sides of the funnel were counted by different mechanisms:
- `detail.view` fired from a mount effect in `StoreDetail`, so leaving the store tab with a detail on screen and coming back counted a second view.
- `card.click` was never emitted from 3 entry points: `FeaturedCard`, `StoreMine` ("My publications"), and the detail-page retry button.

`detail.view` now reports from the `selectStoreApp` action, which every entry point routes through, with an `intent: 'open' | 'reload'` parameter separating real opens from error-recovery reloads. `FeaturedCard` and `StoreMine` now emit `card.click`; the latter is tagged `source: 'mine'` so the browse funnel can exclude it at query time while keeping click ≥ view true everywhere — an inverted ratio then reads as a missing event rather than an uninstrumented surface. A taken-down publication carries no `type` (the server omits it once the app leaves the public index), so the dimension falls back to `'unlisted'` instead of arriving empty.

## Test plan
- [x] `tests/unit/store/discover-page.test.ts`: an 18-member collection resolves fully against a 6-item catalog page; missing members are dropped and counted
- [ ] Client check: a collection configured with 18 members renders all 18 in the discover dialog, with a matching card badge
- [ ] Telemetry check: every entry point emits `card.click` paired with `detail.view`; switching tabs back and forth does not re-count a view
