### PR TITLE
fix: unpack sharp native binaries so oversized images can be resized

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
       "node_modules/@parcel/watcher-*/**/*",
       "node_modules/better-sqlite3/build/Release/*.node",
       "node_modules/node-pty/prebuilds/**",
+      "node_modules/@img/**/*",
       "node_modules/tesseract.js/**",
       "node_modules/tesseract.js-core/**"
     ],

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -13,12 +13,17 @@
 //    with the prebuild matching the target platform. Prebuilds are downloaded
 //    by prepare-binaries.mjs and stored in node_modules/better-sqlite3/prebuilds/.
 //
-// 3. Ensure executable permissions on all native binaries in the unpacked
+// 3. Keep only the target platform's @img/sharp-* package (plus its libvips
+//    sibling) and fail the build if its prebuilt binary is absent. Same
+//    rationale as @parcel/watcher, with an assertion because a missing sharp
+//    binary only surfaces at runtime, on the first oversized image.
+//
+// 4. Ensure executable permissions on all native binaries in the unpacked
 //    output. Some npm packages (e.g. @anthropic-ai/claude-code v2.1.89)
 //    ship tarballs with missing +x on vendored binaries. This step detects
 //    ELF and Mach-O files by magic bytes and adds +x if missing.
 //
-// 4. macOS ad-hoc signing (prevents "damaged app" prompts on unsigned builds).
+// 5. macOS ad-hoc signing (prevents "damaged app" prompts on unsigned builds).
 // ============================================================================
 
 const { execSync } = require('child_process');
@@ -65,6 +70,17 @@ const CLOUDFLARED_VARIANTS = {
   'darwin-x64':   'cloudflared-darwin-x64',
   'win32-x64':    'cloudflared.exe',
   'linux-x64':    'cloudflared-linux-x64',
+};
+
+// Maps platform-arch to the @img/sharp-* package required at runtime. The
+// Claude engines resize oversized images through sharp, which dlopens the
+// prebuilt .node from this package; the libvips sibling it declares is resolved
+// from the same @img directory and kept alongside it.
+const SHARP_TARGETS = {
+  'darwin-arm64': 'sharp-darwin-arm64',
+  'darwin-x64':   'sharp-darwin-x64',
+  'win32-x64':    'sharp-win32-x64',
+  'linux-x64':    'sharp-linux-x64',
 };
 
 // Maps platform-arch to the @openai/codex native package required at runtime.
@@ -296,6 +312,69 @@ function cleanAndValidateCodexNativePackage(context) {
     console.log(`[afterPack] ${key}: removed ${removed.length} non-target Codex package(s): ${removed.join(', ')}`);
   }
   console.log(`[afterPack] ${key}: keeping @openai/${target.packageName}`);
+}
+
+/**
+ * Keep only the target platform's @img/sharp-* package (and the libvips sibling
+ * it declares) in the unpacked output, and fail the build when its prebuilt
+ * binary is missing.
+ *
+ * The binary must live outside the asar archive: a .node cannot be dlopened
+ * from inside the archive, and sharp's only fallback is to give up, which
+ * surfaces to the user as "Unable to resize image" on any oversized image.
+ */
+function cleanAndValidateSharpNativePackage(context) {
+  const platform = context.electronPlatformName;
+  const archStr = ARCH_NAMES[context.arch] || String(context.arch);
+  const key = `${platform}-${archStr}`;
+  const targetPkg = SHARP_TARGETS[key];
+
+  if (!targetPkg) {
+    console.warn(`[afterPack] No sharp package mapping for ${key}, skipping cleanup`);
+    return;
+  }
+
+  const unpackedDir = getUnpackedDir(context);
+  const imgDir = path.join(unpackedDir, 'node_modules', '@img');
+  const targetDir = path.join(imgDir, targetPkg);
+  const targetLibDir = path.join(targetDir, 'lib');
+
+  const hasBinary = fs.existsSync(targetLibDir)
+    && fs.readdirSync(targetLibDir).some(f => f.endsWith('.node'));
+
+  if (!hasBinary) {
+    console.error(`[afterPack] ${key}: missing sharp native binary: ${targetLibDir}`);
+    console.error(`[afterPack] Run "npm run prepare:all" before cross-platform/cross-arch packaging`);
+    console.error(`[afterPack] Also check that asarUnpack includes "node_modules/@img/**/*"`);
+    throw new Error(`Missing @img/${targetPkg} native binary for ${key}`);
+  }
+
+  // The .node links against libvips through an @rpath/RUNPATH pointing at a
+  // sibling directory under @img, so the sibling must survive the cleanup.
+  const manifest = JSON.parse(fs.readFileSync(path.join(targetDir, 'package.json'), 'utf-8'));
+  const siblings = Object.keys(manifest.optionalDependencies || {}).map(dep => dep.split('/').pop());
+
+  const missingSiblings = siblings.filter(name => !fs.existsSync(path.join(imgDir, name, 'lib')));
+  if (missingSiblings.length > 0) {
+    console.error(`[afterPack] ${key}: @img/${targetPkg} needs ${missingSiblings.join(', ')}, not in the unpacked output`);
+    console.error(`[afterPack] Run "npm run prepare:all" to install the libvips sibling`);
+    throw new Error(`Missing libvips package(s) for ${key}: ${missingSiblings.join(', ')}`);
+  }
+
+  const keep = new Set([targetPkg, ...siblings]);
+  const removed = [];
+  for (const entry of fs.readdirSync(imgDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (keep.has(entry.name)) continue;
+
+    fs.rmSync(path.join(imgDir, entry.name), { recursive: true });
+    removed.push(entry.name);
+  }
+
+  if (removed.length > 0) {
+    console.log(`[afterPack] ${key}: removed ${removed.length} non-target sharp package(s): ${removed.join(', ')}`);
+  }
+  console.log(`[afterPack] ${key}: keeping ${[...keep].map(name => `@img/${name}`).join(', ')}`);
 }
 
 /**
@@ -715,6 +794,9 @@ module.exports = async function(context) {
 
   // Ensure the packaged app contains the Codex native binary for this arch.
   cleanAndValidateCodexNativePackage(context);
+
+  // Ensure the packaged app contains the sharp native binary for this arch.
+  cleanAndValidateSharpNativePackage(context);
 
   // Keep only target-platform binaries in @anthropic-ai vendored trees.
   cleanAnthropicVendorBinaries(context);

--- a/scripts/prepare-binaries.mjs
+++ b/scripts/prepare-binaries.mjs
@@ -81,6 +81,20 @@ const CODEX_PACKAGES = {
   'linux': { pkg: '@openai/codex-linux-x64', targetTriple: 'x86_64-unknown-linux-musl', binary: 'codex' }
 }
 
+// @img/sharp-* prebuilt binaries, used by the Claude engines to downscale
+// oversized images before sending them to a model. Declared as optional
+// dependencies of @anthropic-ai/claude-code, so npm installs the host's package
+// only and a cross-platform build would ship none — the app then fails on any
+// image wider than the model limit with "Unable to resize image".
+// Each package pulls its libvips sibling from its own optionalDependencies
+// (win32 has none: the DLLs are inside the package).
+const SHARP_PACKAGES = {
+  'mac-arm64': '@img/sharp-darwin-arm64',
+  'mac-x64': '@img/sharp-darwin-x64',
+  'win': '@img/sharp-win32-x64',
+  'linux': '@img/sharp-linux-x64'
+}
+
 // better-sqlite3 prebuild configuration
 // Prebuilds are platform-specific .node binaries downloaded from GitHub releases.
 // They are stored in node_modules/better-sqlite3/prebuilds/{os}-{arch}/ and
@@ -537,6 +551,107 @@ function installCodex(platform) {
 }
 
 /**
+ * Sharp release to install for every target platform, read from whichever
+ * @img/sharp-* package npm resolved for this host. Pinning all platforms to the
+ * host's version keeps one sharp release across the whole build matrix.
+ */
+function getSharpVersion() {
+  const imgDir = path.join(PROJECT_ROOT, 'node_modules', '@img')
+  const hostPkg = fs.existsSync(imgDir)
+    ? fs.readdirSync(imgDir).find(name => name.startsWith('sharp-') && !name.startsWith('sharp-libvips-'))
+    : undefined
+
+  if (!hostPkg) {
+    throw new Error('No @img/sharp-* package in node_modules, run "npm install" first')
+  }
+  return JSON.parse(fs.readFileSync(path.join(imgDir, hostPkg, 'package.json'), 'utf8')).version
+}
+
+/**
+ * Download an npm package tarball straight into node_modules, bypassing the
+ * host os/cpu checks that make npm refuse a foreign-platform package.
+ */
+function installFromRegistry(pkg, version) {
+  const shortName = pkg.split('/').pop()
+  const registry = execSync('npm config get registry', { encoding: 'utf8' }).trim().replace(/\/+$/, '')
+  const tarballUrl = `${registry}/${pkg}/-/${shortName}-${version}.tgz`
+  const destDir = path.join(PROJECT_ROOT, 'node_modules', ...pkg.split('/'))
+  const tmpTgz = path.join(PROJECT_ROOT, `node_modules/.${shortName}.tgz`)
+
+  try {
+    if (fs.existsSync(destDir)) {
+      fs.rmSync(destDir, { recursive: true })
+    }
+    fs.mkdirSync(destDir, { recursive: true })
+
+    curlDownload(tarballUrl, tmpTgz)
+    execSync(`tar -xzf "${tmpTgz}" -C "${destDir}" --strip-components=1`, { stdio: 'pipe' })
+    fs.unlinkSync(tmpTgz)
+  } catch (err) {
+    if (fs.existsSync(tmpTgz)) fs.unlinkSync(tmpTgz)
+    throw err
+  }
+
+  return destDir
+}
+
+function checkSharp(platform) {
+  const pkg = SHARP_PACKAGES[platform]
+  const pkgDir = path.join(PROJECT_ROOT, 'node_modules', ...pkg.split('/'))
+  const manifestPath = path.join(pkgDir, 'package.json')
+
+  if (!fs.existsSync(manifestPath)) {
+    return { exists: false }
+  }
+
+  const libDir = path.join(pkgDir, 'lib')
+  if (!fs.existsSync(libDir) || !fs.readdirSync(libDir).some(f => f.endsWith('.node'))) {
+    return { exists: true, valid: false }
+  }
+
+  // The libvips sibling carries the shared library the .node links against,
+  // so the package alone is not enough on platforms that declare one.
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  const siblings = Object.keys(manifest.optionalDependencies || {})
+  const valid = siblings.every(dep =>
+    fs.existsSync(path.join(PROJECT_ROOT, 'node_modules', ...dep.split('/'), 'package.json'))
+  )
+  return { exists: true, valid }
+}
+
+/**
+ * Install the @img/sharp-* package for a target platform, plus the libvips
+ * sibling it declares.
+ */
+function installSharp(platform) {
+  const pkg = SHARP_PACKAGES[platform]
+  const version = getSharpVersion()
+
+  log.info(`Installing ${pkg}@${version} from registry...`)
+
+  try {
+    const destDir = installFromRegistry(pkg, version)
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(destDir, 'package.json'), 'utf8'))
+    for (const [dep, range] of Object.entries(manifest.optionalDependencies || {})) {
+      const depVersion = range.replace(/^[^0-9]*/, '')
+      log.info(`Installing ${dep}@${depVersion} for ${pkg}...`)
+      installFromRegistry(dep, depVersion)
+    }
+
+    const status = checkSharp(platform)
+    if (!status.exists || !status.valid) {
+      throw new Error(`No valid sharp binary found in downloaded ${pkg}`)
+    }
+
+    log.success(`Installed ${pkg}@${version}`)
+  } catch (err) {
+    log.error(`Failed to install ${pkg}: ${err.message}`)
+    throw err
+  }
+}
+
+/**
  * Prepare all binaries for a platform
  */
 function preparePlatform(platform) {
@@ -572,6 +687,14 @@ function preparePlatform(platform) {
     installCodex(platform)
   } else {
     log.success(`@openai/codex native package already exists for ${platform}`)
+  }
+
+  // Check and install the @img/sharp-* prebuilt image resizer
+  const sharpStatus = checkSharp(platform)
+  if (!sharpStatus.exists || !sharpStatus.valid) {
+    installSharp(platform)
+  } else {
+    log.success(`@img/sharp native package already exists for ${platform}`)
   }
 
   // Portable Git: bundled into the Windows build for offline Git Bash setup


### PR DESCRIPTION
Closes #279

## 问题

打包后的应用读取宽度 > 2000px 的图片报 `Unable to resize image`，开发模式正常。

## 根因

两个 Claude engine（`@anthropic-ai/claude-code` 和 `claude-agent-sdk`）在把超大图片交给模型前会先缩放，走的是内联的 sharp，最终 `require('@img/sharp-<platform>/sharp.node')`：

```
node_modules/@img/sharp-darwin-arm64/lib/sharp-darwin-arm64.node
node_modules/@img/sharp-libvips-darwin-arm64/lib/libvips-cpp.8.17.3.dylib
```

`build.asarUnpack` 里没有 `@img` 条目，`.node` 被打进 `app.asar`。asar 内的原生模块无法 `dlopen`，sharp 加载失败后没有可用的兜底，直接抛错。小图不触发缩放，所以只有大图复现。

第二个缺口：`@img/*` 是 `optionalDependencies`，npm 按 `os`/`cpu` 只装宿主机那一个。本仓库的 win/linux 包是在 Mac 上交叉打的（`release = electron-builder --mac --win`），所以那些产物里 `@img` 一个都没有——只补 `asarUnpack` 只能修好 mac。

## 改动

1. **`package.json`** — `asarUnpack` 增加 `node_modules/@img/**/*`。整个 `@img` 目录一起解包，是因为 `.node` 通过 `@rpath/@loader_path/../../sharp-libvips-<platform>/lib` 找 libvips，同级目录结构必须保留。

2. **`scripts/prepare-binaries.mjs`** — 与 `@openai/codex` 同样的处理：直接从 registry 拉目标平台的 tarball，绕过 npm 的 os/cpu 校验。libvips 兄弟包从下载下来的 `optionalDependencies` 里读，不硬编码（win32 没有 libvips 包，DLL 在包内）。版本对齐宿主机已解析的 sharp 版本，保证整个构建矩阵同一个 release。

3. **`scripts/afterPack.cjs`** — 删掉非目标平台的 `@img/*`（libvips 单个平台约 15MB），并在缺失时**直接让构建失败**。这类问题不加断言就只能等用户传大图才暴露，与仓库里 codex / cloudflared / engine 的既有做法一致。

## 验证

沙箱内跑真实下载与清理逻辑（无副作用，已清理）：

- `--platform win` → 装到 `sharp-win32-x64`，含 `sharp-win32-x64.node` + `libvips-42.dll` + `libvips-cpp-8.17.3.dll`，无 libvips 兄弟包（符合预期）
- `--platform linux` → 装到 `sharp-linux-x64`，并自动带出 `@img/sharp-libvips-linux-x64@1.2.4`
- 重复执行幂等，第二次输出 `already exists`
- afterPack 用 stub context 跑 darwin-arm64：5 个平台包正确收敛为 `sharp-darwin-arm64` + `sharp-libvips-darwin-arm64`，`.node` 与 `.dylib` 均保留
- 断言用例：删掉目标包 → 抛错；删掉 libvips 兄弟包 → 抛错

未跑完整 electron-builder 打包（耗时且会 bump 版本号）。`node_modules/@img/**/*` 与现有 `node_modules/@parcel/watcher-*/**/*` 是同一形状的 glob；即便解包未生效，新增的 afterPack 断言也会让构建直接失败，不会静默发出坏包。

## 建议的验收方式

发一版 rc，在打包产物里传一张宽度 > 2000px 的图片。