### PR TITLE
feat: add OrcaRouter as a built-in provider

### DIFF
--- a/src/main/openai-compat-router/server/provider-adapters.ts
+++ b/src/main/openai-compat-router/server/provider-adapters.ts
@@ -139,6 +139,35 @@ const requestyAdapter: ProviderAdapter = {
 }
 
 // ============================================================================
+// OrcaRouter Adapter
+// ============================================================================
+
+/**
+ * OrcaRouter supports app attribution headers
+ *
+ * OrcaRouter is an OpenAI-compatible gateway and, like OpenRouter, accepts
+ * optional app attribution headers so requests show up under the app name
+ * in gateway analytics instead of "Unknown".
+ *
+ * @see https://docs.orcarouter.ai
+ */
+const orcaRouterAdapter: ProviderAdapter = {
+  id: 'orcarouter',
+  name: 'OrcaRouter',
+
+  match(url: string): boolean {
+    return url.includes('orcarouter.ai')
+  },
+
+  getExtraHeaders(): Record<string, string> {
+    return {
+      'HTTP-Referer': 'https://hello-halo.cc/',
+      'X-Title': 'Halo'
+    }
+  }
+}
+
+// ============================================================================
 // DeepSeek Adapter
 // ============================================================================
 
@@ -260,6 +289,7 @@ const tencentAdapter: ProviderAdapter = {
 const adapters: readonly ProviderAdapter[] = [
   groqAdapter,
   openRouterAdapter,
+  orcaRouterAdapter,
   requestyAdapter,
   deepSeekAdapter,
   moonshotAdapter,
@@ -323,4 +353,4 @@ export function applyProviderAdapter(
 // Exports
 // ============================================================================
 
-export { groqAdapter, openRouterAdapter, deepSeekAdapter, moonshotAdapter, zhipuAdapter, tencentAdapter }
+export { groqAdapter, openRouterAdapter, orcaRouterAdapter, deepSeekAdapter, moonshotAdapter, zhipuAdapter, tencentAdapter }

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -351,6 +351,29 @@ export const BUILTIN_PROVIDERS: BuiltinProvider[] = [
     notes: 'Requires HTTP-Referer and X-Title headers. Supports model array for failover'
   },
   {
+    id: 'orcarouter',
+    name: 'OrcaRouter',
+    authType: 'api-key',
+    apiUrl: 'https://api.orcarouter.ai/v1',
+    modelsUrl: 'https://api.orcarouter.ai/v1/models',
+    models: [
+      { id: 'orcarouter/auto', name: 'OrcaRouter Auto (Adaptive)' },
+      { id: 'openai/gpt-5.5', name: 'GPT-5.5' },
+      { id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' },
+      { id: 'anthropic/claude-opus-4.8', name: 'Claude Opus 4.8' },
+      { id: 'grok/grok-4.3', name: 'Grok 4.3' },
+      { id: 'deepseek/deepseek-v4-pro', name: 'DeepSeek V4 Pro' },
+      { id: 'minimax/minimax-m2.7', name: 'MiniMax M2.7' },
+      { id: 'qwen/qwen3.7-max', name: 'Qwen3.7 Max' }
+    ],
+    description: 'OrcaRouter AI gateway with adaptive routing across 190+ models',
+    website: 'https://www.orcarouter.ai/',
+    region: 'global',
+    recommended: true,
+    icon: 'route',
+    notes: 'orcarouter/auto is a virtual router, not a model — it routes each request to the best upstream. Model list fetched dynamically'
+  },
+  {
     id: 'atlascloud',
     name: 'Atlas Cloud',
     authType: 'api-key',

--- a/src/shared/types/ai-sources.ts
+++ b/src/shared/types/ai-sources.ts
@@ -75,6 +75,7 @@ export type BuiltinProviderId =
   | 'yi'
   | 'stepfun'
   | 'openrouter'
+  | 'orcarouter'
   | 'atlascloud'
   | 'requesty'
   | 'groq'

--- a/tests/unit/services/provider-adapters.test.ts
+++ b/tests/unit/services/provider-adapters.test.ts
@@ -8,6 +8,7 @@ import {
   deepSeekAdapter,
   groqAdapter,
   openRouterAdapter,
+  orcaRouterAdapter,
   moonshotAdapter,
   zhipuAdapter
 } from '../../../src/main/openai-compat-router/server/provider-adapters'
@@ -148,6 +149,18 @@ describe('findAdapter', () => {
   it('finds openrouter adapter by URL', () => {
     const adapter = findAdapter('https://openrouter.ai/api/v1')
     expect(adapter?.id).toBe('openrouter')
+  })
+
+  it('finds orcarouter adapter by URL', () => {
+    const adapter = findAdapter('https://api.orcarouter.ai/v1')
+    expect(adapter?.id).toBe('orcarouter')
+  })
+
+  it('attaches app attribution headers for the app', () => {
+    expect(orcaRouterAdapter.getExtraHeaders?.()).toEqual({
+      'HTTP-Referer': 'https://hello-halo.cc/',
+      'X-Title': 'Halo'
+    })
   })
 
   it('returns undefined for unknown URL without adapterId', () => {

--- a/tests/unit/shared/providers.test.ts
+++ b/tests/unit/shared/providers.test.ts
@@ -29,3 +29,33 @@ describe('Atlas Cloud built-in provider', () => {
     ])
   })
 })
+
+describe('OrcaRouter built-in provider', () => {
+  it('registers an OpenAI-compatible gateway provider with dynamic model discovery', () => {
+    const provider = getBuiltinProvider('orcarouter')
+
+    expect(provider).toMatchObject({
+      id: 'orcarouter',
+      authType: 'api-key',
+      apiUrl: 'https://api.orcarouter.ai/v1',
+      modelsUrl: 'https://api.orcarouter.ai/v1/models',
+      region: 'global'
+    })
+    expect(provider?.recommended).toBe(true)
+    expect(getAllProviderIds()).toContain('orcarouter')
+  })
+
+  it('leads with the virtual auto router, then flagship model ids', () => {
+    expect(getDefaultModel('orcarouter')).toBe('orcarouter/auto')
+    expect(getBuiltinProvider('orcarouter')?.models.map(model => model.id)).toEqual([
+      'orcarouter/auto',
+      'openai/gpt-5.5',
+      'google/gemini-3.5-flash',
+      'anthropic/claude-opus-4.8',
+      'grok/grok-4.3',
+      'deepseek/deepseek-v4-pro',
+      'minimax/minimax-m2.7',
+      'qwen/qwen3.7-max'
+    ])
+  })
+})


### PR DESCRIPTION
Add [OrcaRouter](https://www.orcarouter.ai) as a built-in provider so Halo users can point their AI sources at it with just an API key, the same way they already do for OpenRouter. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

The change mirrors the existing OpenRouter wiring in `src/shared/constants/providers.ts`: a new `orcarouter` entry in `BUILTIN_PROVIDERS` pointing at `https://api.orcarouter.ai/v1`, with the model list fetched dynamically from `/v1/models`. The preset models lead with `orcarouter/auto`, a virtual router that routes each request to the best upstream (configurable in the OrcaRouter console) — all flagship model ids are verified against the live catalog. A matching provider adapter in `src/main/openai-compat-router/server/provider-adapters.ts` attaches the same `HTTP-Referer` / `X-Title` app attribution headers OpenRouter and Requesty already send, so requests show up under Halo in gateway analytics.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verification: the two touched unit suites pass (`tests/unit/shared/providers.test.ts`, `tests/unit/services/provider-adapters.test.ts`), and the live OrcaRouter endpoint returns 200 for `orcarouter/auto` with and without tools, plus `openai/gpt-5.5`, `anthropic/claude-opus-4.8`, and the `/v1/models` list.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
