### PR TITLE
fix: show native tooltips and surface agent description for truncated team rows

### DIFF
--- a/src/renderer/components/chat/SubAgentTimeline.tsx
+++ b/src/renderer/components/chat/SubAgentTimeline.tsx
@@ -39,9 +39,13 @@ const SubAgentToolRow = memo(function SubAgentToolRow({ thought }: { thought: Th
   const hasResult = !!thought.toolResult
   const isError = thought.toolResult?.isError
 
-  const friendlyContent = useMemo(
-    () => truncateText(getToolFriendlyFormat(thought.toolName || '', thought.toolInput), 60),
+  const fullContent = useMemo(
+    () => getToolFriendlyFormat(thought.toolName || '', thought.toolInput),
     [thought.toolName, thought.toolInput]
+  )
+  const friendlyContent = useMemo(
+    () => truncateText(fullContent, 60),
+    [fullContent]
   )
 
   const ToolIcon = getToolIcon(thought.toolName || '')
@@ -65,7 +69,7 @@ const SubAgentToolRow = memo(function SubAgentToolRow({ thought }: { thought: Th
         </span>
 
         {/* Friendly summary */}
-        <span className="text-xs text-muted-foreground/60 truncate min-w-0 flex-1">
+        <span className="text-xs text-muted-foreground/60 truncate min-w-0 flex-1" title={fullContent || undefined}>
           {friendlyContent}
         </span>
 
@@ -143,7 +147,16 @@ export function SubAgentTimeline({ thoughts, parentToolUseId, taskProgress, isTh
         )}
 
         {/* Status summary */}
-        <span className="flex-1 text-left truncate">
+        <span
+          className="flex-1 text-left truncate"
+          title={
+            isRunning && isThinking
+              ? taskProgress?.lastToolName
+                ? `${t('Running')} ${taskProgress.lastToolName}...`
+                : t('Running...')
+              : `${toolCount} ${t('tools used')}`
+          }
+        >
           {isRunning && isThinking ? (
             taskProgress?.lastToolName
               ? `${t('Running')} ${taskProgress.lastToolName}...`

--- a/src/renderer/components/chat/TeamPanel.tsx
+++ b/src/renderer/components/chat/TeamPanel.tsx
@@ -151,12 +151,15 @@ const TeamAgentRow = memo(function TeamAgentRow({ agent }: { agent: DerivedTeamA
       <StatusDot status={agent.status} />
 
       {/* Name */}
-      <span className="font-medium text-foreground shrink-0 max-w-[100px] truncate">
+      <span className="font-medium text-foreground shrink-0 max-w-[100px] truncate" title={agent.name}>
         {agent.name}
       </span>
 
       {/* Summary */}
-      <span className="flex-1 text-muted-foreground truncate min-w-0 text-xs">
+      <span
+        className="flex-1 text-muted-foreground truncate min-w-0 text-xs"
+        title={[agent.description, agent.summary].filter(Boolean).join(' — ') || undefined}
+      >
         {agent.summary}
       </span>
 
@@ -251,10 +254,13 @@ export function TeamSnapshotPanel({ thoughts }: TeamSnapshotPanelProps) {
         {agents.map(agent => (
           <div key={agent.thoughtId} className="flex items-center gap-2 py-0.5 text-xs min-w-0">
             <StatusDot status={agent.status} />
-            <span className="font-medium text-foreground shrink-0 max-w-[100px] truncate">
+            <span className="font-medium text-foreground shrink-0 max-w-[100px] truncate" title={agent.name}>
               {agent.name}
             </span>
-            <span className="flex-1 text-muted-foreground/70 truncate min-w-0">
+            <span
+              className="flex-1 text-muted-foreground/70 truncate min-w-0"
+              title={[agent.description, agent.summary].filter(Boolean).join(' — ') || undefined}
+            >
               {agent.summary}
             </span>
             {agent.durationMs > 0 && (


### PR DESCRIPTION
## Summary
- Hovering a truncated sub-agent name or status summary in the team panel now shows the full text via a native `title` tooltip
- `DerivedTeamAgent.description` (the agent's task description) is surfaced for the first time — combined into the summary tooltip
- Same tooltip treatment applied to both live view and snapshot/history view rows, plus the sub-agent timeline's tool rows and status header

## Related Issue
Fixes #359

## Changes
- `src/renderer/components/chat/TeamPanel.tsx` — added `title` attributes to truncated name/summary spans in `TeamAgentRow` and `TeamSnapshotPanel`; summary tooltip joins `description` + full `summary`
- `src/renderer/components/chat/SubAgentTimeline.tsx` — extracted untruncated content for tooltips on tool-row friendly summaries and the running/status header

## Testing
- [x] Ran `npm run i18n` (no new keys; locale files unchanged)
- [x] `npx tsc -p tsconfig.web.json --noEmit` — no new errors vs baseline
- [ ] Ran `npm run dev` and hovered truncated rows to verify tooltips render in live and history team views

Fixes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)