### PR TITLE
fix: fade the bottom edge of the sidebar pulse list to hint hidden tasks

### DIFF
--- a/src/renderer/assets/styles/globals.css
+++ b/src/renderer/assets/styles/globals.css
@@ -226,6 +226,14 @@ body {
   scrollbar-color: hsl(var(--muted-foreground) / 0.2) transparent;
 }
 
+/* Scroll edge fade hint for overflow containers whose scrollbar is too subtle
+ * to signal "more content below". Applied as a mask on the whole scroll area,
+ * so the underlying list stays fully rendered while the bottom edge fades. */
+.scroll-fade-down {
+  mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+}
+
 /* Disable text selection on UI elements */
 .no-select {
   user-select: none;

--- a/src/renderer/components/chat/ConversationList.tsx
+++ b/src/renderer/components/chat/ConversationList.tsx
@@ -18,6 +18,7 @@ import { TaskStatusDot } from '../pulse/TaskStatusDot'
 import { PulseSidebarSection } from '../pulse/PulseSidebarSection'
 import { AutomationBadge } from '../apps/AutomationBadge'
 import { EngineBadge } from './EngineBadge'
+import { useScrollableFade } from '../../hooks/useScrollableFade'
 import type { ConversationMeta } from '../../types'
 
 // Width constraints (in pixels)
@@ -68,6 +69,10 @@ export const ConversationList = memo(function ConversationList({
   const widthRef = useRef(width)
   const topSectionHeightRef = useRef(initialTopSectionHeight ?? DEFAULT_TOP_SECTION_HEIGHT)
   const [topSectionHeight, setTopSectionHeight] = useState(topSectionHeightRef.current)
+
+  // Bottom-edge fade hint on the pinned/running-tasks block: the thin scrollbar
+  // alone doesn't signal that more items are hidden below the dragged height.
+  const [topSectionScrollRef, topSectionCanScroll] = useScrollableFade<HTMLDivElement>()
 
   // Sync width when config arrives asynchronously
   useEffect(() => {
@@ -384,8 +389,11 @@ export const ConversationList = memo(function ConversationList({
         {/* Automation apps status badge — quick jump to AppsPage */}
         <AutomationBadge />
 
-        {/* Pinned section - fills remaining space and scrolls within the dragged height */}
-        <div className="flex-1 min-h-0 overflow-y-auto">
+        {/* Pinned section - scrolls within the dragged height; fade bottom edge when more items are hidden below */}
+        <div
+          ref={topSectionScrollRef}
+          className={`flex-1 min-h-0 overflow-y-auto ${topSectionCanScroll ? 'scroll-fade-down' : ''}`}
+        >
           {visible && <PulseSidebarSection />}
         </div>
 

--- a/src/renderer/hooks/useScrollableFade.ts
+++ b/src/renderer/hooks/useScrollableFade.ts
@@ -1,0 +1,53 @@
+/**
+ * useScrollableFade - Track whether a scrollable element has more content hidden below.
+ *
+ * Returns a ref to attach to the scroll container plus a boolean that is true
+ * when the container overflows and the user has not scrolled to the bottom.
+ * Useful for showing a bottom-edge fade hint when the scrollbar alone is too
+ * subtle to signal cut-off content (see .scroll-fade-down in globals.css).
+ *
+ * Usage:
+ *   const [scrollRef, canScrollDown] = useScrollableFade<HTMLDivElement>()
+ *   <div ref={scrollRef} className={canScrollDown ? 'scroll-fade-down' : ''}>...
+ */
+
+import { useEffect, useRef, useState, type MutableRefObject } from 'react'
+
+export function useScrollableFade<T extends HTMLElement>(): [MutableRefObject<T | null>, boolean] {
+  const ref = useRef<T | null>(null)
+  const [canScrollDown, setCanScrollDown] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    let rafId = 0
+    const update = () => {
+      rafId = 0
+      const hasOverflow = el.scrollHeight - el.clientHeight > 1
+      const isAtBottom = el.scrollTop >= el.scrollHeight - el.clientHeight - 1
+      setCanScrollDown(hasOverflow && !isAtBottom)
+    }
+    // Coalesce rapid DOM/layout changes (live task updates) into one check per frame
+    const scheduleUpdate = () => {
+      if (!rafId) rafId = requestAnimationFrame(update)
+    }
+
+    scheduleUpdate()
+    el.addEventListener('scroll', scheduleUpdate, { passive: true })
+    const resizeObserver = new ResizeObserver(scheduleUpdate)
+    resizeObserver.observe(el)
+    // Content can grow/shrink without resizing the container (e.g. task list changes)
+    const mutationObserver = new MutationObserver(scheduleUpdate)
+    mutationObserver.observe(el, { subtree: true, childList: true })
+
+    return () => {
+      el.removeEventListener('scroll', scheduleUpdate)
+      resizeObserver.disconnect()
+      mutationObserver.disconnect()
+      if (rafId) cancelAnimationFrame(rafId)
+    }
+  }, [])
+
+  return [ref, canScrollDown]
+}


### PR DESCRIPTION
## Summary
- When the pinned/running-tasks block at the top of the conversation sidebar overflows its (user-draggable) height, a bottom-edge gradient fade now signals that more items are scrollable
- Works at any panel height, including the persisted minimum (80px), and updates live as tasks are added/removed or the divider is dragged
- Uses a CSS mask on the scroll area, so the underlying list stays fully rendered

## Related Issue
Fixes #366

## Changes
- `src/renderer/components/chat/ConversationList.tsx` — attach scroll-overflow tracking to the pulse section wrapper and toggle the fade class
- `src/renderer/hooks/useScrollableFade.ts` — new hook (rAF-throttled scroll + ResizeObserver + MutationObserver) reporting whether content is hidden below
- `src/renderer/assets/styles/globals.css` — `.scroll-fade-down` mask (bottom 20% gradient), following the existing `canvas-tabs.css` mask convention

## Testing
- [x] `npx tsc -p tsconfig.web.json --noEmit` — no new errors vs baseline
- [x] Ran `npm run i18n` (no new text; locale files unchanged)
- [ ] Ran `npm run dev` — verified the fade appears when tasks overflow, disappears when scrolled to bottom or content fits, and tracks divider drags at all heights

Fixes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)